### PR TITLE
Do not redraw after horizontal cursor move

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -79,8 +79,11 @@ function! agit#show_commit()
   elseif s:old_hash !=# hash
     call agit#bufwin#set_to_stat(t:git.stat(hash))
     call agit#bufwin#set_to_diff(t:git.diff(hash))
+  else
+    return 0
   endif
   let s:old_hash = hash
+  return 1
 endfunction
 
 function! s:remote_scroll(win_type, direction)

--- a/ftplugin/agit.vim
+++ b/ftplugin/agit.vim
@@ -53,9 +53,10 @@ function! s:wait_for_show_commit()
 endfunction
 
 function! s:show_commit()
-  call agit#show_commit()
   call s:cleanup()
-  redraw!
+  if agit#show_commit()
+    redraw!
+  endif
 endfunction
 
 function! s:cleanup()


### PR DESCRIPTION
Now agit redraws window whenever the cursor is moved.
But it's not necessary when moved in the same line.
