### PR TITLE
Make enable to launch AgitFile from directory other than repository root

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -59,6 +59,8 @@ function! agit#launch(args)
     if !filereadable(git.path)
         throw "File not found: " . git.path
     endif
+    let git.abspath = fnamemodify(git.path, ':p')
+    let git.relpath = git.normalizepath(git.abspath)
     let git.views = parsed_args.preset
     call agit#bufwin#agit_tabnew(git)
     let t:git = git

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -87,7 +87,7 @@ function! s:git.log(winwidth) dict
 endfunction
 
 function! s:git.filelog(winwidth)
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- ' . self.path, self.git_dir)
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- ' . self.abspath, self.git_dir)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
@@ -125,6 +125,11 @@ function! s:git.diff(hash) dict
   endif
   return diff
 endfunction
+
+function! s:git.normalizepath(path)
+  let path = agit#git#exec('ls-tree --full-name --name-only HEAD ' . a:path, self.git_dir)
+  return s:String.chomp(path)
+endfunction                                                                                     
 
 function! s:git.catfile(hash, path)
   let catfile = agit#git#exec('cat-file -p ' . a:hash . ':' . a:path, self.git_dir)

--- a/autoload/agit/view/catfile.vim
+++ b/autoload/agit/view/catfile.vim
@@ -21,7 +21,7 @@ endfunction
 
 function! s:catfile.render(hash)
   call agit#bufwin#move_to(self.name)
-  call s:fill_buffer(self.git.catfile(a:hash, self.git.path))
+  call s:fill_buffer(self.git.catfile(a:hash, self.git.relpath))
 endfunction
 
 function! s:catfile.setlocal()


### PR DESCRIPTION
※ #14 のPRに不具合があったため、修正してHEADにrebaseしました

現在のコードだと、カレントディレクトリがリポジトリルート以外の場合AgitFileが正しく動きません (git 1.9.4で確認しています)
- リポジトリ外のディレクトリの場合：
  E684エラーが発生し、ログが表示されない
- リポジトリ内のサブディレクトリの場合：
  ログは表示されるが、ファイルの内容が表示されず、代わりに以下のようなエラーが発生する
  (agitのリポジトリで、autoload/をカレントにしてautoload/agit.vimのログを表示しようとした場合の例です。
  コロン以下の部分がautoload/agit.vimになるべきなのにagit.vimだけになっているのがエラーの原因です)
  `fatal: Not a valid object name faa103c:agit.vim`

このパッチによって上記の問題が解消されます。
