### PR TITLE
Ignore backslash escape.

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -132,7 +132,7 @@ function! s:git.diff(hash) dict
 endfunction
 
 function! s:git.normalizepath(path)
-  let path = agit#git#exec('ls-tree --full-name --name-only HEAD "' . a:path . '"', self.git_dir)
+  let path = agit#git#exec('ls-tree --full-name --name-only HEAD ''' . a:path . '''', self.git_dir)
   return s:String.chomp(path)
 endfunction
 


### PR DESCRIPTION
If the path contains backslash, error ouccured as Agit command runs. 

This change ignore backslash in the path.
The path is enclosed with single quotation instead of double quotation.