### PR TITLE
Add a variable g:agit_diff_option

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -117,7 +117,8 @@ function! s:git.stat(hash) dict
   elseif a:hash ==# 'nextpage'
     let stat = ''
   else
-    let stat = agit#git#exec('show --oneline --stat --date=iso --pretty=format: '. a:hash, self.git_dir)
+    let ignoresp = g:agit_ignore_spaces ? '-w' : ''
+    let stat = agit#git#exec('show --oneline --stat --date=iso --pretty=format: ' . ignoresp . ' ' . a:hash, self.git_dir)
     let stat = substitute(stat, '^[\n\r]\+', '', '')
   endif
   return stat
@@ -131,7 +132,8 @@ function! s:git.diff(hash) dict
   elseif a:hash ==# 'nextpage'
     let diff = ''
   else
-    let diff = agit#git#exec('show -p ' . a:hash, self.git_dir)
+    let ignoresp = g:agit_ignore_spaces ? '-w' : ''
+    let diff = agit#git#exec('show -p '. ignoresp .' ' . a:hash, self.git_dir)
   endif
   return diff
 endfunction

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -246,6 +246,11 @@ g:agit_localchanges_always_on_top		*g:agit_skip_empty_line*
 	always on the top of |agit-log|.
 	default value: 1
 
+g:agit_ignore_spaces				*g:agit_ignore_spaces*
+	If it is non-zero, Agit ignore whitespace changes as showing
+	|agit-diff| and |agit-stat| buffer.
+	default value: 1
+
 
 ==============================================================================
 TODO						*agit-todo*

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -24,6 +24,9 @@ endif
 if !exists('g:agit_localchanges_always_on_top')
   let g:agit_localchanges_always_on_top = 1
 endif
+if !exists('g:agit_ignore_spaces')
+    let g:agit_ignore_spaces = 1
+endif
 
 nnoremap <silent> <Plug>(agit-reload)  :<C-u>call agit#reload()<CR>
 nnoremap <silent> <Plug>(agit-scrolldown-stat) :<C-u>call agit#remote_scroll('stat', 'down')<CR>


### PR DESCRIPTION
This is new feature.

I add g:agit_diff_option variable.
It is passed to git-show command  as Agit show agit_diff and agit_stat buffer.

It makes possible tracking rename file , ignore space difference and more!