### PR TITLE
Fix for AgitFile on a non-tracked file (fix #13)

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -60,6 +60,9 @@ function! agit#launch(args)
         throw "Agit: File not found: " . git.path
     endif
     let git.abspath = fnamemodify(git.path, ':p')
+    if parsed_args.presetname ==# 'file' && agit#git#exec('ls-files "' . git.abspath . '"', git.git_dir) ==# ''
+        throw "Agit: File not tracked: " . git.path
+    endif
     let git.relpath = git.normalizepath(git.abspath)
     let git.views = parsed_args.preset
     call agit#bufwin#agit_tabnew(git)


### PR DESCRIPTION
#13 への修正です。
AgitFileコマンドで、ファイルがgitで管理されているかどうかチェックします。