### PR TITLE
make enabled to show one file diff with vimdiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features
 --------
 * gitk-like repository viewer
 * providing various git commands (e.g. checkout, reset, etc...)
+* side by side diff by vimdiff
 * No fugitive dependency, but well cooperation if exists.
 * Supporting multibyte character
 

--- a/autoload/agit/diff.vim
+++ b/autoload/agit/diff.vim
@@ -1,0 +1,26 @@
+function! agit#diff#sidebyside(git, relpath, lhash, rhash) abort
+  tabnew
+  call s:fill_buffer(a:git, a:relpath, a:lhash)
+  botright vnew
+  call s:fill_buffer(a:git, a:relpath, a:rhash)
+  windo diffthis
+endfunction
+
+function! s:fill_buffer(git, relpath, hash) abort
+  if a:hash ==# 'unstaged'
+    edit! `=a:git.to_abspath(a:relpath)`
+  elseif a:hash ==# 'staged' && get(g:, 'loaded_fugitive', 0)
+    edit! `='fugitive://' . a:git.git_dir . '//0/' . a:relpath`
+  else
+    let content = a:git.catfile(a:hash, a:relpath)
+    silent! file `=a:relpath . '(' . a:hash . ')'`
+    doautocmd BufNewFile `=a:relpath`
+    setlocal noswapfile buftype=nofile bufhidden=delete
+    setlocal modifiable
+    noautocmd silent! %delete _
+    noautocmd silent! 1put= content
+    noautocmd silent! 1delete _
+    setlocal nomodifiable 
+  endif
+endfunction
+

--- a/autoload/agit/view/filelog.vim
+++ b/autoload/agit/view/filelog.vim
@@ -4,6 +4,10 @@ let s:filelog = {
 
 function! agit#view#filelog#new(git)
   let filelog = extend(agit#view#log#new(a:git), s:filelog)
+  command! AgitDiff call agit#diff()
+  if !g:agit_no_default_mappings
+    nmap <silent><buffer> di <Plug>(agit-diff)
+  endif
   return filelog
 endfunction
 

--- a/autoload/agit/view/stat.vim
+++ b/autoload/agit/view/stat.vim
@@ -34,5 +34,9 @@ function! s:stat.setlocal()
   setlocal winfixheight
   setlocal noswapfile
   nmap <buffer> q <Plug>(agit-exit)
+  command! AgitDiff call agit#diff()
+  if !g:agit_no_default_mappings
+    nmap <silent><buffer> di <Plug>(agit-diff)
+  endif
   set filetype=agit_stat
 endfunction

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -122,6 +122,20 @@ COMMANDS					*agit-commands*
 	If you specify !, this command uses |:!| instead of |system()|.
 	(Same as |fugitive|'s |:Git|)
 
+						*:AgitDiff*
+:AgitDiff
+	Show |vimdiff| against the target file of the current revision.
+	Note: This command is available only in |agit-log| buffer from
+	|:AgitFile| and |agit-stat| buffer.
+
+	When launched from |agit-log| buffer, target of |:AgitFile| is treated
+	as target file.
+	When launched from |agit-stat| buffer, AgitDiff trys to pick target file
+	from cursor position. (see |<cfile>|)
+
+	If you installed |fugitive|, AgitDiff uses |fugitive| when showing staged
+	file. This means you can stage or unstage each hunks like |:Gdiff|.
+
 ------------------------------------------------------------------------------
 KEY-MAPPINGS					*agit-key-mappings*
 
@@ -190,6 +204,9 @@ In |agit-log| buffer, the following key mappings can be used.
 <Plug>(agit-git-revert)				*<Plug>(agit-git-revert)*
 	Execute 'git revert' to revert the cursor line commit.
 
+<Plug>(agit-diff)				*<Plug>(agit-diff)*
+	Show |vimdiff| against the target file of the current revision.
+
 ------------------------------------------------------------------------------
 DEFAULT KEY-MAPPINGS				*agit-default-key-mappings*
 
@@ -209,6 +226,7 @@ rm			<Plug>(agit-git-reset)
 rh			<Plug>(agit-git-reset-hard)
 rb			<Plug>(agit-git-rebase)
 ri			<Plug>(agit-git-rebase-i)
+di			<Plug>(agit-diff)
 
 ------------------------------------------------------------------------------
 VARIABLES					*agit-variables*

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -37,6 +37,7 @@ nnoremap <silent> <Plug>(agit-scrollup-diff)   :<C-u>call agit#remote_scroll('di
 nnoremap <silent> <PLug>(agit-yank-hash) :<C-u>call agit#yank_hash()<CR>
 nnoremap <silent> <Plug>(agit-show-commit) :<C-u>call agit#show_commit()<CR>
 nnoremap <silent> <Plug>(agit-print-commitmsg) :<C-u>call agit#print_commitmsg()<CR>
+nnoremap <silent> <Plug>(agit-diff) :<C-u>AgitDiff<CR>
 
 nnoremap <silent> <Plug>(agit-git-checkout)     :<C-u>AgitGit checkout <branch><CR>
 nnoremap <silent> <Plug>(agit-git-checkout-b)   :<C-u>AgitGit checkout -b \%# <hash><CR>


### PR DESCRIPTION
side by side diffの機能が欲しいのでとりあえず実装してみました。

agit-stat　bufferでファイルパスにカーソルを置いて `:AgitDiff<CR>` または `di` で、そのファイルのdiffを新しいタブに表示します。
`:AgitFile` で表示されるlogからも同じように起動できます。

もしこの実装でOKなら、READMEも更新してPRを出し直そうと思います。