### PR TITLE
Support --separate-git-dir

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -60,7 +60,7 @@ function! agit#launch(args)
         throw "Agit: File not found: " . git.path
     endif
     let git.abspath = fnamemodify(git.path, ':p')
-    if parsed_args.presetname ==# 'file' && agit#git#exec('ls-files "' . git.abspath . '"', git.git_dir) ==# ''
+    if parsed_args.presetname ==# 'file' && agit#git#exec('ls-files "' . git.abspath . '"', git.git_dir, git.worktree_dir) ==# ''
         throw "Agit: File not tracked: " . git.path
     endif
     let git.relpath = git.normalizepath(git.abspath)
@@ -189,7 +189,7 @@ function! agit#agitgit(arg, confirm, bang)
   let arg = substitute(a:arg, '\c<hash>', agit#extract_hash(getline('.')), 'g')
   if match(arg, '\c<branch>') >= 0
     let cword = expand('<cword>')
-    silent let branch = agit#git#exec('rev-parse --symbolic ' . cword, t:git.git_dir)
+    silent let branch = agit#git#exec('rev-parse --symbolic ' . cword, t:git.git_dir, t:git.worktree_dir)
     let branch = substitute(branch, '\n\+$', '', '')
     if agit#git#get_last_status() != 0
       echomsg 'Not a branch name: ' . cword
@@ -210,7 +210,7 @@ function! agit#agitgit(arg, confirm, bang)
         return
       endif
     endif
-    echo agit#git#exec(arg, t:git.git_dir, a:bang)
+    echo agit#git#exec(arg, t:git.git_dir, t:git.worktree_dir, a:bang)
     call agit#reload()
   endif
 endfunction
@@ -227,7 +227,7 @@ function! agit#agit_git_compl(arglead, cmdline, cursorpos)
 endfunction
 
 function! agit#revision_list()
-  let revs = agit#git#exec('rev-parse --symbolic --branches --remotes --tags', t:git.git_dir)
+  let revs = agit#git#exec('rev-parse --symbolic --branches --remotes --tags', t:git.git_dir, t:git.worktree_dir)
   \ . join(['HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'FETCH_HEAD'], "\n")
   let hash = agit#extract_hash(getline('.'))
   if hash != ''
@@ -238,21 +238,21 @@ function! agit#revision_list()
 endfunction
 
 function! s:git_checkout(branch_name)
-  echo agit#git#exec('checkout ' . a:branch_name, t:git.git_dir)
+  echo agit#git#exec('checkout ' . a:branch_name, t:git.git_dir, t:git.worktree_dir)
   call agit#reload()
 endfunction
 
 function! s:git_checkout_b()
   let branch_name = input('git checkout -b ')
   echo ''
-  echo agit#git#exec('checkout -b ' . branch_name, t:git.git_dir)
+  echo agit#git#exec('checkout -b ' . branch_name, t:git.git_dir, t:git.worktree_dir)
   call agit#reload()
 endfunction
 
 function! s:git_branch_d(branch_name)
   echon "Are you sure you want to delete branch '" . a:branch_name . "' [y/N]"
   if nr2char(getchar()) ==# 'y'
-    echo agit#git#exec('branch -D ' . a:branch_name, t:git.git_dir)
+    echo agit#git#exec('branch -D ' . a:branch_name, t:git.git_dir, t:git.worktree_dir)
     call agit#reload()
   endif
 endfunction

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -177,22 +177,26 @@ function! agit#git#exec(command, git_dir, worktree_dir, ...)
   if a:0 > 0 && a:1 == 1
     execute '!' . cmd
   else
-    if s:Process.has_vimproc() && s:P.is_windows()
-      let ret = vimproc#system(cmd)
-      let s:last_status = vimproc#get_last_status()
-    else
-      let ret = system(cmd)
-      let s:last_status = v:shell_error
-    endif
-    if s:is_cp932
-      let ret = iconv(ret, 'utf-8', 'cp932')
-    endif
-    return ret
+    return s:system(cmd)
   endif
 endfunction
 
 function! s:get_worktree_dir(git_dir)
   return matchstr(a:git_dir, '^.\+\ze\.git')
+endfunction
+
+function! s:system(cmd)
+  if s:Process.has_vimproc() && s:P.is_windows()
+    let ret = vimproc#system(a:cmd)
+    let s:last_status = vimproc#get_last_status()
+  else
+    let ret = system(a:cmd)
+    let s:last_status = v:shell_error
+  endif
+  if s:is_cp932
+    let ret = iconv(ret, 'utf-8', 'cp932')
+  endif
+  return ret
 endfunction
 
 function! agit#git#get_last_status()

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -182,7 +182,17 @@ function! agit#git#exec(command, git_dir, worktree_dir, ...)
 endfunction
 
 function! s:get_worktree_dir(git_dir)
-  return matchstr(a:git_dir, '^.\+\ze\.git')
+  let worktree_relpath = s:String.chomp(s:system('git --no-pager --git-dir="' . a:git_dir . '" config --get core.worktree'))
+  if worktree_relpath == ''
+    let worktree_dir = matchstr(a:git_dir, '^.\+\ze\.git')
+  else
+    let cdcmd = haslocaldir() ? 'lcd ' : 'cd '
+    let cwd = getcwd()
+    execute cdcmd . a:git_dir
+    let worktree_dir = fnamemodify(worktree_relpath, ':p')
+    execute cdcmd . cwd
+  endif
+  return worktree_dir
 endfunction
 
 function! s:system(cmd)

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -11,6 +11,7 @@ let g:agit#git#nextpage_message = '(too many logs)'
 
 let s:git = {
 \ 'git_dir' : '',
+\ 'worktree_dir' : '',
 \ 'hash': '',
 \ 'oninit': [],
 \ 'onhashchange': [],
@@ -24,7 +25,7 @@ let s:git = {
 \ }}
 
 function! s:git.log(winwidth) dict
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir)
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir, self.worktree_dir)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
@@ -38,7 +39,7 @@ function! s:git.log(winwidth) dict
   " add staged and unstaged lines
   let self.staged = self._localchanges(1, '')
   let self.unstaged = self._localchanges(0, '')
-  let untracked = agit#git#exec('ls-files --others --exclude-standard', self.git_dir)
+  let untracked = agit#git#exec('ls-files --others --exclude-standard', self.git_dir, self.worktree_dir)
   if !empty(untracked)
     if self.unstaged.stat !=# ''
       let self.unstaged.stat .= "\n"
@@ -52,7 +53,7 @@ function! s:git.log(winwidth) dict
 endfunction
 
 function! s:git.filelog(winwidth)
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- "' . self.abspath . '"', self.git_dir)
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- "' . self.abspath . '"', self.git_dir, self.worktree_dir)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
@@ -77,7 +78,7 @@ function! s:git._localchanges(cached, relpath) dict
   if !empty(a:relpath)
     let cmd .= ' -- "' . a:relpath . '"'
   endif
-  let diff = agit#git#exec(cmd, self.git_dir)
+  let diff = agit#git#exec(cmd, self.git_dir, self.worktree_dir)
   let split = s:String.nsplit(diff, 2, '\n\n')
   let ret = {'stat' : '', 'diff' : ''}
   if len(split) == 2
@@ -93,7 +94,7 @@ function! s:git._insert_localchanges_loglines(aligned_log) dict
   if g:agit_localchanges_always_on_top
     let head_index = 0
   else
-    let head_hash = agit#git#exec('rev-parse --short HEAD', self.git_dir)
+    let head_hash = agit#git#exec('rev-parse --short HEAD', self.git_dir, self.worktree_dir)
     let head_index = s:List.find_index(a:aligned_log, 'match(v:val, "\\[' . s:String.chomp(head_hash) . '\\]") >= 0')
   endif
 
@@ -114,7 +115,7 @@ function! s:git.stat(hash) dict
     let stat = ''
   else
     let ignoresp = g:agit_ignore_spaces ? '-w' : ''
-    let stat = agit#git#exec('show --oneline --stat --date=iso --pretty=format: ' . ignoresp . ' ' . a:hash, self.git_dir)
+    let stat = agit#git#exec('show --oneline --stat --date=iso --pretty=format: ' . ignoresp . ' ' . a:hash, self.git_dir, self.worktree_dir)
     let stat = substitute(stat, '^[\n\r]\+', '', '')
   endif
   return stat
@@ -129,13 +130,13 @@ function! s:git.diff(hash) dict
     let diff = ''
   else
     let ignoresp = g:agit_ignore_spaces ? '-w' : ''
-    let diff = agit#git#exec('show -p '. ignoresp .' ' . a:hash, self.git_dir)
+    let diff = agit#git#exec('show -p '. ignoresp .' ' . a:hash, self.git_dir, self.worktree_dir)
   endif
   return diff
 endfunction
 
 function! s:git.normalizepath(path)
-  let path = agit#git#exec('ls-tree --full-name --name-only HEAD ''' . a:path . '''', self.git_dir)
+  let path = agit#git#exec('ls-tree --full-name --name-only HEAD ''' . a:path . '''', self.git_dir, self.worktree_dir)
   return s:String.chomp(path)
 endfunction
 
@@ -149,20 +150,21 @@ function! s:git.catfile(hash, path)
   elseif a:hash == 'unstaged'
     let catfile = join(readfile(self.to_abspath(a:path)), "\n")
   elseif a:hash == 'staged'
-    let catfile = agit#git#exec('cat-file -p ":' . a:path . '"', self.git_dir)
+    let catfile = agit#git#exec('cat-file -p ":' . a:path . '"', self.git_dir, self.worktree_dir)
   else
-    let catfile = agit#git#exec('cat-file -p "' . a:hash . ':' . a:path . '"', self.git_dir)
+    let catfile = agit#git#exec('cat-file -p "' . a:hash . ':' . a:path . '"', self.git_dir, self.worktree_dir)
   endif
   return catfile
 endfunction
 
 function! s:git.commitmsg(hash) dict
-  return agit#git#exec('show -s --format=format:%s ' . a:hash, self.git_dir)
+  return agit#git#exec('show -s --format=format:%s ' . a:hash, self.git_dir, self.worktree_dir)
 endfunction
 
 let s:seq = ''
 function! agit#git#new(git_dir)
-  let git = extend(deepcopy(s:git), {'git_dir' : a:git_dir, 'seq': s:seq})
+  let worktree_dir = s:get_worktree_dir(a:git_dir)
+  let git = extend(deepcopy(s:git), {'git_dir' : a:git_dir, 'worktree_dir' : worktree_dir, 'seq': s:seq})
   let s:seq += 1
   return git
 endfunction
@@ -170,9 +172,8 @@ endfunction
 " Utilities
 let s:last_status = 0
 let s:is_cp932 = &enc == 'cp932'
-function! agit#git#exec(command, git_dir, ...)
-  let worktree_dir = matchstr(a:git_dir, '^.\+\ze\.git')
-  let cmd = 'git --no-pager --git-dir="' . a:git_dir . '" --work-tree="' . worktree_dir . '" ' . a:command
+function! agit#git#exec(command, git_dir, worktree_dir, ...)
+  let cmd = 'git --no-pager --git-dir="' . a:git_dir . '" --work-tree="' . a:worktree_dir . '" ' . a:command
   if a:0 > 0 && a:1 == 1
     execute '!' . cmd
   else
@@ -188,6 +189,10 @@ function! agit#git#exec(command, git_dir, ...)
     endif
     return ret
   endif
+endfunction
+
+function! s:get_worktree_dir(git_dir)
+  return matchstr(a:git_dir, '^.\+\ze\.git')
 endfunction
 
 function! agit#git#get_last_status()

--- a/test/agit.vim
+++ b/test/agit.vim
@@ -9,6 +9,7 @@ function! s:suite.__in_clean_repo__()
 
   let clean = themis#suite('in clean repo')
   let s:clean_repo_path = s:repo_path . 'clean/.git'
+  let s:clean_worktree_path = s:repo_path . 'clean'
 
   function! clean.before()
     tabnew
@@ -23,13 +24,13 @@ function! s:suite.__in_clean_repo__()
 
   function! clean.appear_only_commits_at_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:clean_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:clean_repo_path, s:clean_worktree_path))
     call Expect(getline(1)).to_match(head_hash)
   endfunction
 
   function! clean.show_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat HEAD~', s:clean_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat HEAD~', s:clean_repo_path, s:clean_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -58,13 +59,13 @@ function! s:suite.__in_clean_repo_with_empty_buffer__()
 
   function! clean.appear_only_commits_at_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:clean_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:clean_repo_path, s:clean_worktree_path))
     call Expect(getline(1)).to_match(head_hash)
   endfunction
 
   function! clean.show_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat HEAD~', s:clean_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat HEAD~', s:clean_repo_path, s:clean_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -74,6 +75,7 @@ function! s:suite.__in_unstaged_repo__()
 
   let unstaged = themis#suite('in unstaged repo')
   let s:unstaged_repo_path = s:repo_path . 'unstaged/.git'
+  let s:unstaged_worktree_path = s:repo_path . 'unstaged'
 
   function! unstaged.before()
     tabnew
@@ -93,13 +95,13 @@ function! s:suite.__in_unstaged_repo__()
 
   function! unstaged.appear_commit_mesesage_at_second_line_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:unstaged_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:unstaged_repo_path, s:unstaged_worktree_path))
     call Expect(getline(2)).to_match(head_hash)
   endfunction
 
   function! unstaged.show_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat', s:unstaged_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat', s:unstaged_repo_path, s:unstaged_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -109,6 +111,7 @@ function! s:suite.__in_untracked_repo__()
 
   let untracked = themis#suite('in untracked repo')
   let s:untracked_repo_path = s:repo_path . 'untracked/.git'
+  let s:untracked_worktree_path = s:repo_path . 'untracked'
 
   function! untracked.before()
     tabnew
@@ -128,13 +131,13 @@ function! s:suite.__in_untracked_repo__()
 
   function! untracked.appear_commit_mesesage_at_second_line_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:untracked_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:untracked_repo_path, s:untracked_worktree_path))
     call Expect(getline(2)).to_match(head_hash)
   endfunction
 
   function! untracked.show_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let untracked_files = s:String.chomp(agit#git#exec('ls-files --others --exclude-standard', s:untracked_repo_path))
+    let untracked_files = s:String.chomp(agit#git#exec('ls-files --others --exclude-standard', s:untracked_repo_path, s:untracked_worktree_path))
     call Expect(s:String.trim(getline('$'))).to_equal(untracked_files)
   endfunction
 
@@ -149,6 +152,7 @@ function! s:suite.__in_staged_repo__()
 
   let staged = themis#suite('in staged repo')
   let s:staged_repo_path = s:repo_path . 'staged/.git'
+  let s:staged_worktree_path = s:repo_path . 'staged'
 
   function! staged.before()
     tabnew
@@ -168,13 +172,13 @@ function! s:suite.__in_staged_repo__()
 
   function! staged.appear_commit_mesesage_at_second_line_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:staged_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:staged_repo_path, s:staged_worktree_path))
     call Expect(getline(2)).to_match(head_hash)
   endfunction
 
   function! staged.show_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --cached --shortstat', s:staged_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --cached --shortstat', s:staged_repo_path, s:staged_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -184,6 +188,7 @@ function! s:suite.__in_mixed_repo__()
 
   let mixed = themis#suite('in mixed repo')
   let s:mixed_repo_path = s:repo_path . 'mixed/.git'
+  let s:mixed_worktree_path = s:repo_path . 'mixed'
 
   function! mixed.before()
     tabnew
@@ -209,13 +214,13 @@ function! s:suite.__in_mixed_repo__()
 
   function! mixed.show_commit_mesesage_at_third_line_log_window()
     call agit#bufwin#move_to('log')
-    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:mixed_repo_path))
+    let head_hash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', s:mixed_repo_path, s:mixed_worktree_path))
     call Expect(getline(3)).to_match(head_hash)
   endfunction
 
   function! mixed.show_unstaged_diff_stat_result_at_stat_window()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat', s:mixed_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --shortstat', s:mixed_repo_path, s:mixed_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -224,7 +229,7 @@ function! s:suite.__in_mixed_repo__()
     2
     call agit#show_commit()
     call agit#bufwin#move_to('stat')
-    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --cached --shortstat', s:mixed_repo_path)))
+    let stat_msg = s:String.trim(s:String.chomp(agit#git#exec('diff --cached --shortstat', s:mixed_repo_path, s:mixed_worktree_path)))
     call Expect(s:String.trim(getline('$'))).to_equal(stat_msg)
   endfunction
 
@@ -248,7 +253,7 @@ function! s:suite.__reload_test__()
 
   function! reload.after_each()
     call delete(s:repo_path . 'clean/x')
-    call agit#git#exec('reset', t:git.git_dir)
+    call agit#git#exec('reset', t:git.git_dir, t:git.worktree_dir)
   endfunction
 
   function! reload.on_log_window()
@@ -330,6 +335,7 @@ function! s:suite.__in_execute_repo__()
 
   let execute = themis#suite('in execute repo')
   let s:execute_repo_path = s:repo_path . 'execute/.git'
+  let s:execute_worktree_path = s:repo_path . 'execute'
 
   function! execute.before()
     tabnew
@@ -342,17 +348,17 @@ function! s:suite.__in_execute_repo__()
     call agit#bufwin#move_to('log')
     call search('develop', 'wc')
     execute 'AgitGit checkout ' . expand('<cword>')
-    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path))
+    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path, s:execute_worktree_path))
     call Expect(current_branch).to_equal('develop')
     call search('master', 'wc')
     execute 'AgitGit checkout ' . expand('<cword>')
-    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path))
+    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path, s:execute_worktree_path))
     call Expect(current_branch).to_equal('master')
   endfunction
 
   function! execute.git_create_b()
     execute 'AgitGit checkout -b new ' . agit#extract_hash(getline(2))
-    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path))
+    let current_branch = s:String.chomp(agit#git#exec('rev-parse --abbrev-ref HEAD', s:execute_repo_path, s:execute_worktree_path))
     call Expect(current_branch).to_equal('new')
     call Expect(getline(2)).to_match('(HEAD, new')
   endfunction
@@ -362,7 +368,7 @@ function! s:suite.__in_execute_repo__()
     execute "normal \<Plug>(agit-git-checkout)"
     call search('new', 'wc')
     execute 'AgitGit branch -d ' . expand("<cword>")
-    let current_branches = s:String.chomp(agit#git#exec('branch', s:execute_repo_path))
+    let current_branches = s:String.chomp(agit#git#exec('branch', s:execute_repo_path, s:execute_worktree_path))
     call Expect(current_branches).to_equal("  develop\n* master")
   endfunction
 


### PR DESCRIPTION
git clone時に--separate-git-dir=...オプションを使用して作業ツリーを分離したリポジトリをagit.vimで見た際、
未コミット差分が "fatal: This operation must be run in a work tree" とエラーになってしまっていたので、
修正してみました。

基本的に「core.worktreeが設定されていたら作業ツリーとして優先的に採用する」という処理を追加しただけですが、
毎回git configを呼ぶのも如何なものかと思い、dictに持たせるよう変更しました。