### PR TITLE
Make stat width customizable

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -114,7 +114,7 @@ function! s:git.stat(hash) dict
     let stat = ''
   else
     let ignoresp = g:agit_ignore_spaces ? '-w' : ''
-    let stat = agit#git#exec('show --oneline --stat --date=iso --pretty=format: ' . ignoresp . ' ' . a:hash, self.git_dir)
+    let stat = agit#git#exec('show --oneline --stat=' . g:agit_stat_width . ' --date=iso --pretty=format: ' . ignoresp . ' ' . a:hash, self.git_dir)
     let stat = substitute(stat, '^[\n\r]\+', '', '')
   endif
   return stat

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -273,6 +273,10 @@ g:agit_ignore_spaces				*g:agit_ignore_spaces*
 	|agit-diff| and |agit-stat| buffer.
 	default value: 1
 
+g:agit_stat_width				*g:agit_stat_width*
+	Max columns of |agit-stat| buffer.
+	default value: 80
+
 
 ==============================================================================
 TODO						*agit-todo*

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -27,6 +27,9 @@ endif
 if !exists('g:agit_ignore_spaces')
     let g:agit_ignore_spaces = 1
 endif
+if !exists('g:agit_stat_width')
+    let g:agit_stat_width = 80
+endif
 
 nnoremap <silent> <Plug>(agit-reload)  :<C-u>call agit#reload()<CR>
 nnoremap <silent> <Plug>(agit-scrolldown-stat) :<C-u>call agit#remote_scroll('stat', 'down')<CR>


### PR DESCRIPTION
agit-statバッファの各行は最大80文字のため、ファイルのパスが長いとパスが省略されてしまいます。
そうなるとAgitDiffの実行ができなくなってしまうため、最大文字数を変更できるように修正してみました。