### PR TITLE
Improve reload behavior

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -105,17 +105,19 @@ function! agit#print_commitmsg()
 endfunction
 
 function! agit#remote_scroll(win_type, direction)
-  if a:win_type ==# 'stat'
-    call agit#bufwin#move_to('stat')
-  elseif a:win_type ==# 'diff'
-    call agit#bufwin#move_to('diff')
+  if !exists('w:view')
+    return
+  endif
+  let win_save = w:view.name
+  if !agit#bufwin#move_to(a:win_type)
+    return
   endif
   if a:direction ==# 'down'
     execute "normal! \<C-d>"
   elseif a:direction ==# 'up'
     execute "normal! \<C-u>"
   endif
-  call agit#bufwin#move_to('log')
+  call agit#bufwin#move_to(win_save)
 endfunction
 
 function! agit#yank_hash()
@@ -142,10 +144,15 @@ function! agit#show_commit()
 endfunction
 
 function! agit#reload() abort
-  if !exists('t:git')
+  if !exists('t:git') || !exists('w:view')
     return
   endif
-  call t:git.fire_init()
+  try
+    let win_save = w:view.name
+    call t:git.fire_init()
+  finally
+    call agit#bufwin#move_to(win_save)
+  endtry
 endfunction
 
 function! agit#diff() abort

--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -145,12 +145,7 @@ function! agit#reload() abort
   if !exists('t:git')
     return
   endif
-  let pos_save = getpos('.')
-  try
-    call t:git.fire_init()
-  finally
-    call setpos('.', pos_save)
-  endtry
+  call t:git.fire_init()
 endfunction
 
 function! agit#diff() abort

--- a/autoload/agit/view/diff.vim
+++ b/autoload/agit/view/diff.vim
@@ -38,6 +38,15 @@ function! s:diff.setlocal()
   setlocal nocursorline nocursorcolumn
   setlocal winfixheight
   setlocal noswapfile
-  nmap <buffer> q <Plug>(agit-exit)
+
+  if !g:agit_no_default_mappings
+    nmap <silent><buffer> u <PLug>(agit-reload)
+    nmap <silent><buffer> J <Plug>(agit-scrolldown-stat)
+    nmap <silent><buffer> K <Plug>(agit-scrollup-stat)
+
+    nmap <silent><buffer> q <Plug>(agit-exit)
+  endif
+
+
   set filetype=agit_diff
 endfunction

--- a/autoload/agit/view/filelog.vim
+++ b/autoload/agit/view/filelog.vim
@@ -20,7 +20,5 @@ function! s:fill_buffer(str)
 endfunction
 
 function! s:filelog.render()
-  call agit#bufwin#move_to(self.name)
-  call s:fill_buffer(self.git.filelog(winwidth(0)))
-  call self.emmit(1)
+  call self.renderwith('filelog')
 endfunction

--- a/autoload/agit/view/stat.vim
+++ b/autoload/agit/view/stat.vim
@@ -33,9 +33,14 @@ function! s:stat.setlocal()
   setlocal nocursorline nocursorcolumn
   setlocal winfixheight
   setlocal noswapfile
-  nmap <buffer> q <Plug>(agit-exit)
   command! -buffer AgitDiff call agit#diff()
+
   if !g:agit_no_default_mappings
+    nmap <silent><buffer> u <PLug>(agit-reload)
+    nmap <silent><buffer> <C-j> <Plug>(agit-scrolldown-diff)
+    nmap <silent><buffer> <C-k> <Plug>(agit-scrollup-diff)
+    nmap <silent><buffer> q <Plug>(agit-exit)
+
     nmap <silent><buffer> di <Plug>(agit-diff)
   endif
   set filetype=agit_stat

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -139,28 +139,35 @@ COMMANDS					*agit-commands*
 ------------------------------------------------------------------------------
 KEY-MAPPINGS					*agit-key-mappings*
 
-In |agit-log| buffer, the following key mappings can be used.
+The following key mappings can be used.
 (All of these mappings are buffer-local mappings)
+Available only in |agit-log| buffer unless explicitly mentioned.
 
 <Plug>(agit-scrolldown-stat)			*<Plug>(agit-scrolldown-stat)*
 	Scroll downwards the |agit-stat| window. The number of scroll lines is the
 	half a window.
+	Available in |agit-log|, |agit-diff|
+
 	TODO: Allow to customize the scroll size
 
 <Plug>(agit-scrollup-stat)			*<Plug>(agit-scrollup-stat)*
 	Scroll upwards the |agit-stat| window. The number of scroll lines is the
 	half a window.
+	Available in |agit-log|, |agit-diff|
 
 <Plug>(agit-scrolldown-diff)			*<Plug>(agit-scrolldown-diff)*
 	Scroll upwards the |agit-diff| window. The number of scroll lines is the
 	half a window.
+	Available in |agit-log|, |agit-stat|
 
 <Plug>(agit-scrollup-diff)			*<Plug>(agit-scrollup-diff)*
 	Scroll downwards the |agit-diff| window. The number of scroll lines is the
 	half a window.
+	Available in |agit-log|, |agit-stat|
 
 <Plug>(agit-reload)				*<Plug>(agit-reload)*
-	Manually update the |agit-log| buffer.
+	Manually update the agit buffers.
+	Available in |agit-log|, |agit-stat|, |agit-diff|
 
 <PLug>(agit-yank-hash)				*<Plug>(agit-yank-hash)*
 	Yank the hash of the commit under the cursor
@@ -170,6 +177,7 @@ In |agit-log| buffer, the following key mappings can be used.
 
 <PLug>(agit-exit)				*<Plug>(agit-exit)*
 	Exit from agit.
+	Available in |agit-log|, |agit-stat|, |agit-diff|
 
 <Plug>(agit-git-checkout)			*<Plug>(agit-git-checkout)*
 	Execute 'git checkout' to change the current branch which under the
@@ -204,11 +212,9 @@ In |agit-log| buffer, the following key mappings can be used.
 <Plug>(agit-git-revert)				*<Plug>(agit-git-revert)*
 	Execute 'git revert' to revert the cursor line commit.
 
-
-In |agit-log| and |agit-stat| buffer, the following key mappings can be used.
-
 <Plug>(agit-diff)				*<Plug>(agit-diff)*
 	Show |vimdiff| against the target file of the current revision.
+	Availabie in |agit-log|, |agit-stat|
 
 
 ------------------------------------------------------------------------------
@@ -241,7 +247,7 @@ g:agit_no_default_mappings			*g:agit_no_default_mappings*
 	default value: 0
 
 g:agit_enable_auto_show_commit			*g:agit_enable_auto_show_commit*
-	If it is non-zero, |agit-stat| and |agit-diff|| buffers are
+	If it is non-zero, |agit-stat| and |agit-diff| buffers are
 	automatically updated when the cursor moved in |agit-log| buffer.
 	default value: 1
 

--- a/test/agit.vim
+++ b/test/agit.vim
@@ -261,16 +261,14 @@ function! s:suite.__reload_test__()
     call Expect(getline(1)).not.to_match(g:agit#git#unstaged_message)
     call agit#bufwin#move_to('stat')
     call agit#reload()
-    call Expect(w:view.name).to_equal('log')
-    call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
+    call Expect(w:view.name).to_equal('stat')
   endfunction
 
   function! reload.on_diff_window()
     call Expect(getline(1)).not.to_match(g:agit#git#unstaged_message)
     call agit#bufwin#move_to('diff')
     call agit#reload()
-    call Expect(w:view.name).to_equal('log')
-    call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
+    call Expect(w:view.name).to_equal('diff')
   endfunction
 
   function! reload.when_extra_window_exists()


### PR DESCRIPTION
このPRは、リロードの動作を以下のように変更します。

## reload後のコミット選択
いくつかのケースを除いて、リロード前後で同じコミットが選択されるようにします（現在は行番号で決めているので、commit/reset/fetchなどの後では選択されるコミットが変わる）

例外となるケースは以下の通りです。
* HEADが選択された状態でリロードして、HEADが移動した場合 -> 新しいHEADを選択する
* HEADが選択されていてSTAGED/UNSTAGEDが表示されていない状態でリロードして、STAGEDまたはUNSTAGEDが表示された場合 -> そちらを選択する

また、この修正に伴って　#35　の問題が解消されています。

## stat/diffからの呼び出し
``<Plug>(agit-reload)``を、agit-stat と agit-diffバッファでも使えるようにします。
ついでにremote scroll系のキーバインディングも使えるようにしています。
