### PR TITLE
Use default diff vim highlighting groups instead of custom ones

### DIFF
--- a/syntax/agit_diff.vim
+++ b/syntax/agit_diff.vim
@@ -21,10 +21,10 @@ syn match agitDiffIndex /^index.*$/ display contained
 syn match agitDiffLine /^@@ -.\{-}@@.*$/ display contained contains=agitDiffSubname
 syn match agitDiffSubname /^\%(@@ -.\{-}@@\)\zs.*$/ display contained
 
-hi def link agitDiffAdd Identifier
-hi def link agitDiffAddMerge Identifier
-hi def link agitDiffRemove Special
-hi def link agitDiffRemoveMerge Special
+hi def link agitDiffAdd diffAdd
+hi def link agitDiffAddMerge diffAdd
+hi def link agitDiffRemove diffDelete
+hi def link agitDiffRemoveMerge diffDelete
 hi def link agitDiffHeader Type
 hi def link agitHeaderLabel Label
 hi def link agitDiffFileName Comment

--- a/syntax/agit_stat.vim
+++ b/syntax/agit_stat.vim
@@ -9,8 +9,8 @@ syn match agitStatMessage /^\ \d\+\ files\?\ changed.*$/
 syn match agitUntrackedTitle /^ -- untracked files --$/
 syn match agitUntrackedFile /^ \f\+$/
 
-hi def link agitStatAdded Identifier
-hi def link agitStatRemoved Special
+hi def link agitStatAdded diffAdd
+hi def link agitStatRemoved diffDelete
 hi def link agitStatFile Constant
 hi def link agitStatMessage Title
 hi def link agitUntrackedTitle Structure


### PR DESCRIPTION
It makes more sense to use default diff hi-groups instead of custom ones.

e.g with my [own colorscheme](https://github.com/kabbamine/yowish.vim):

Before:

![before](https://cloud.githubusercontent.com/assets/5658084/12288428/79839dde-b9e5-11e5-8eb8-d751cb6b5819.png)

After:

![after](https://cloud.githubusercontent.com/assets/5658084/12288431/8014fb84-b9e5-11e5-9c46-5de5702840db.png)

