### PR TITLE
Fix: agit can't show correct stat when conflicting

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -81,22 +81,13 @@ function! s:git._head() dict
 endfunction
 
 function! s:git._localchanges(cached, relpath) dict
-  let cmd = 'diff --stat=' . g:agit_stat_width . ' -p'
-  if a:cached
-    let cmd .= ' --cached'
-  endif
+  let opts = a:cached ? ' --cached' : ''
   if !empty(a:relpath)
-    let cmd .= ' -- "' . a:relpath . '"'
+    let opts .= ' -- "' . a:relpath . '"'
   endif
-  let diff = agit#git#exec(cmd, self.git_dir)
-  let split = s:String.nsplit(diff, 2, '\n\n')
-  let ret = {'stat' : '', 'diff' : '', 'line' : 0}
-  if len(split) == 2
-    let ret.stat = split[0]
-    let ret.diff = split[1]
-  elseif len(split) == 1
-    let ret.diff = split[0]
-  endif
+  let ret = {'line' : 0}
+  let ret.stat = agit#git#exec('diff --stat=' . g:agit_stat_width . opts, self.git_dir)
+  let ret.diff = agit#git#exec('diff -p' . opts, self.git_dir)
   return ret
 endfunction
 


### PR DESCRIPTION
Working Treeにコンフリクトがあると `git diff --stat -p` と指定してもstatが表示されないため、agit-statのウインドウがちゃんと表示されません。

gitの実行回数が増えてしまうのがいまひとつですが、statとpatchを別々に取るように修正してみました。
(git diff --stat -pを実行してみて結果にstatが含まれない場合だけ別々に取るようにしようかとも思ったのですが、patchにたまたま空行が2連続で含まれていた場合などに誤認しそうなのでやめました。)