### PR TITLE
Improve s:agit_preset_views to accept custom setting

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -17,7 +17,7 @@ let s:agit_vital = {
 \ 'OptionParser' : s:OptionParser,
 \ }
 
-let s:agit_preset_views = {
+let s:agit_preset_views = get(g:, 'agit_preset_views', {
 \ 'default': [
 \   {'name': 'log'},
 \   {'name': 'stat',
@@ -29,7 +29,7 @@ let s:agit_preset_views = {
 \   {'name': 'filelog'},
 \   {'name': 'catfile',
 \    'layout': 'botright vnew'},
-\ ]}
+\ ]})
 let s:fugitive_enabled = get(g:, 'loaded_fugitive', 0)
 
 let s:parser = s:OptionParser.new()


### PR DESCRIPTION
# 実現したいこと
個別のファイルの git log と同時に diff も確認したい

# 現在
デフォルトで指定されている`s:agit_preset_views` では、`filelog` と、`catfile` しか追えない

# このPRでできるようになること
デフォルトで指定されている`s:agit_preset_views` を vimrc 側の設定で上書きすることができる。

ex:
```vim
let g:agit_preset_views = {
\ 'default': [
\   {'name': 'log'},
\   {'name': 'stat',
\    'layout': 'botright vnew'},
\   {'name': 'diff',
\    'layout': 'belowright {winheight(".") * 3 / 4}new'}
\ ],
\ 'file': [
\   {'name': 'filelog'},
\   {'name': 'stat',
\    'layout': 'botright vnew'},
\   {'name': 'diff',
\    'layout': 'belowright {winheight(".") * 3 / 4}new'}
\ ]}
```