### PR TITLE
Use max-count based on g:agit_max_log_lines for performance improvement

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -28,7 +28,8 @@ let s:git = {
 \ }
 
 function! s:git.log(winwidth) dict
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir)
+  let max_count = g:agit_max_log_lines + 1
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
@@ -57,7 +58,8 @@ function! s:git.log(winwidth) dict
 endfunction
 
 function! s:git.filelog(winwidth)
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- "' . self.abspath . '"', self.git_dir)
+  let max_count = g:agit_max_log_lines + 1
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- "' . self.abspath . '"', self.git_dir)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')


### PR DESCRIPTION
This pull request uses `--max-count` to trim the output of the `git log` command. This improves the performance.

1. The time consumed by the `git log` command (or, `system()` function) is reduced.
2. The time consumed by the `substitute()` function is reduced (`let gitlog = substitute...`).

The below is profiling results of `:Agit` five times on a repository with over 20000 commits.

## Before
```
FUNCTION  27()
Called 5 times
Total time:  33.298371
 Self time:   2.268857

count  total (s)   self (s)
    5  14.787355   0.000248   let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir)
                              " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
    5              0.000068   let max_width = a:winwidth + 16
    5              0.303402   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
    5              0.330819   let gitlog = substitute(gitlog, '\<refs/remotes/', 'r:', 'g')
    5              0.275582   let gitlog = substitute(gitlog, '\<refs/tags/', 't:', 'g')
    5              1.354866   let log_lines = map(split(gitlog, "\n"), 'split(v:val, s:sep)')
                            
    5   1.204486   0.000994   let aligned_log = agit#aligner#align(log_lines, max_width)
    5   2.440965   0.000177   let self.head = self._head()
                            
                              " TODO: strange message will be shown when merge conflicted
                              " add staged and unstaged lines
    5   4.348417   0.000211   let self.staged = self._localchanges(1, '')
    5   5.933063   0.000260   let self.unstaged = self._localchanges(0, '')
    5   2.317137   0.000236   let untracked = agit#git#exec('ls-files --others --exclude-standard', self.git_dir)
    5              0.000034   if !empty(untracked)
                                if self.unstaged.stat !=# ''
                                  let self.unstaged.stat .= "\n"
                                endif
                                let untracked2 = join(map(split(untracked, "\n"), "' ' . v:val"), "\n")
                                let self.unstaged.stat .= "\n -- untracked files --\n" . untracked2
                              endif
    5   0.000327   0.000110   call self._insert_localchanges_loglines(aligned_log)
                            
    5              0.001327   return join(aligned_log, "\n")
```

## After
```
FUNCTION  27()
Called 5 times
Total time:  21.126905
 Self time:   0.045044

count  total (s)   self (s)
    5              0.000018   let log_lines = g:agit_max_log_lines + 1
    5   4.777929   0.000182   let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . log_lines . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_dir)
                              " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
    5              0.000032   let max_width = a:winwidth + 16
    5              0.005946   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
    5              0.005344   let gitlog = substitute(gitlog, '\<refs/remotes/', 'r:', 'g')
    5              0.005019   let gitlog = substitute(gitlog, '\<refs/tags/', 't:', 'g')
    5              0.023852   let log_lines = map(split(gitlog, "\n"), 'split(v:val, s:sep)')
                            
    5   1.184216   0.001964   let aligned_log = agit#aligner#align(log_lines, max_width)
    5   2.226700   0.000112   let self.head = self._head()
                            
                              " TODO: strange message will be shown when merge conflicted
                              " add staged and unstaged lines
    5   4.495865   0.000183   let self.staged = self._localchanges(1, '')
    5   5.888134   0.000167   let self.unstaged = self._localchanges(0, '')
    5   2.511645   0.000291   let untracked = agit#git#exec('ls-files --others --exclude-standard', self.git_dir)
    5              0.000051   if !empty(untracked)
    5              0.000039     if self.unstaged.stat !=# ''
                                  let self.unstaged.stat .= "\n"
                                endif
    5              0.000259     let untracked2 = join(map(split(untracked, "\n"), "' ' . v:val"), "\n")
    5              0.000051     let self.unstaged.stat .= "\n -- untracked files --\n" . untracked2
    5              0.000006   endif
    5   0.000356   0.000085   call self._insert_localchanges_loglines(aligned_log)
                            
    5              0.001261   return join(aligned_log, "\n")
```