### PR TITLE
Use vital#system on every environment

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -200,7 +200,7 @@ function! s:get_git_dir(basedir)
   let cdcmd = haslocaldir() ? 'lcd ' : 'cd '
   let cwd = getcwd()
   execute cdcmd . current_path
-  if s:Process.has_vimproc() && s:P.is_windows()
+  if s:Process.has_vimproc()
     let toplevel_path = vimproc#system('git --no-pager rev-parse --show-toplevel')
     let has_error = vimproc#get_last_status() != 0
   else

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -182,7 +182,7 @@ function! agit#git#exec(command, git_dir, ...)
   if a:0 > 0 && a:1 == 1
     execute '!' . cmd
   else
-    if s:Process.has_vimproc() && s:P.is_windows()
+    if s:Process.has_vimproc()
       let ret = vimproc#system(cmd)
       let s:last_status = vimproc#get_last_status()
     else


### PR DESCRIPTION
I noticed that `vimproc#system` is avoided on non-Windows system. There *used* to be a performance problem a while ago, but *currently* `vimproc#system` is much faster than `system`.

`:Agit` 10 times on a large repository.

||`agit#launch` (total) |`agit#git#exec`|`s:get_git_dir`|
|:--:|:--:|:--:|:--:|
|Before|31.513161s|27.229926s|2.910941s|
|After|8.232178s|6.714214s|0.154262s|


## Details
### Before
```vim
FUNCTION  agit#git#exec()
Called 80 times
Total time:  27.229926
 Self time:   0.052551

count  total (s)   self (s)
   80              0.002727   let worktree_dir = matchstr(a:git_dir, '^.\+\ze\.git')
   80              0.000525   let cmd = 'git --no-pager --git-dir="' . a:git_dir . '" --work-tree="' . worktree_dir . '" ' . a:command
   80              0.000155   if a:0 > 0 && a:1 == 1
                                execute '!' . cmd
                              else
   80   0.002628   0.001197     if s:Process.has_vimproc() && s:P.is_windows()
                                  let ret = vimproc#system(cmd)
                                  let s:last_status = vimproc#get_last_status()
                                else
   80  27.220903   0.044959       let ret = system(cmd)
   80              0.000864       let s:last_status = v:shell_error
   80              0.000148     endif
   80              0.000142     if s:is_cp932
                                  let ret = iconv(ret, 'utf-8', 'cp932')
                                endif
   80              0.000622     return ret
                              endif

FUNCTION  <SNR>22_get_git_dir()
Called 10 times
Total time:   2.910941
 Self time:   0.012785

count  total (s)   self (s)
   10              0.000019   if empty(a:basedir)
                                " if fugitive exists
   10              0.000017     if s:fugitive_enabled && exists('b:git_dir')
                                  return b:git_dir
                                else
   10              0.002289       let current_path = expand('%:p:h')
   10              0.000010     endif
   10              0.000004   else
                                let current_path = a:basedir
                              endif
   10              0.000026   let cdcmd = haslocaldir() ? 'lcd ' : 'cd '
   10              0.000400   let cwd = getcwd()
   10              0.001040   execute cdcmd . current_path
   10   0.004159   0.000133   if s:Process.has_vimproc() && s:P.is_windows()
                                let toplevel_path = vimproc#system('git --no-pager rev-parse --show-toplevel')
                                let has_error = vimproc#get_last_status() != 0
                              else
   10   2.900115   0.006548     let toplevel_path = system('git --no-pager rev-parse --show-toplevel')
   10              0.000117     let has_error = v:shell_error != 0
   10              0.000029   endif
   10              0.001637   execute cdcmd . cwd
   10              0.000087   if has_error
                                throw 'Agit: Not a git repository.'
                              endif
   10   0.000787   0.000224   return s:String.chomp(toplevel_path) . '/.git'

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
   10  31.513161   0.002255  agit#launch()
   80  27.229926   0.052551  agit#git#exec()
   10  25.375140   0.002608  agit#bufwin#agit_tabnew()
   10  25.264266   0.000151  18()
   10  25.264115   0.000083  20()
   10  25.264032   0.008825  21()
   10  25.237550   0.056546  7()
   20  13.028995   0.001467  10()
   10   3.221915   0.000401  14()
   10   2.910941   0.012785  <SNR>22_get_git_dir()
   10   2.892403   0.000369  9()
   10   1.168782   0.388933  agit#aligner#align()
 5000   0.644144   0.032641  <SNR>40_fillncate()
 5000   0.575900   0.110916  agit#string#truncate()
 1810   0.464984   0.440475  <SNR>26_strwidthpart()
 5000   0.135418             <SNR>26_trim()
 5000   0.035466             agit#string#fill_right()
   10   0.034442   0.000226  agit#view#diff#new()
   10   0.034216   0.021715  28()
   10   0.033857   0.000216  agit#view#log#new()
```

### After
```vim
FUNCTION  agit#git#exec()
Called 80 times
Total time:   6.714214
 Self time:   0.006317

count  total (s)   self (s)
   80              0.001595   let worktree_dir = matchstr(a:git_dir, '^.\+\ze\.git')
   80              0.000432   let cmd = 'git --no-pager --git-dir="' . a:git_dir . '" --work-tree="' . worktree_dir . '" ' . a:command
   80              0.000110   if a:0 > 0 && a:1 == 1
                                execute '!' . cmd
                              else
   80   0.001583   0.000631     if s:Process.has_vimproc()
   80   6.708777   0.002041       let ret = vimproc#system(cmd)
   80   0.000670   0.000461       let s:last_status = vimproc#get_last_status()
   80              0.000050     else
                                  let ret = system(cmd)
                                  let s:last_status = v:shell_error
                                endif
   80              0.000075     if s:is_cp932
                                  let ret = iconv(ret, 'utf-8', 'cp932')
                                endif
   80              0.000213     return ret
                              endif

FUNCTION  <SNR>22_get_git_dir()
Called 10 times
Total time:   0.154262
 Self time:   0.006676

count  total (s)   self (s)
   10              0.000022   if empty(a:basedir)
                                " if fugitive exists
   10              0.000021     if s:fugitive_enabled && exists('b:git_dir')
                                  return b:git_dir
                                else
   10              0.002197       let current_path = expand('%:p:h')
   10              0.000011     endif
   10              0.000005   else
                                let current_path = a:basedir
                              endif
   10              0.000028   let cdcmd = haslocaldir() ? 'lcd ' : 'cd '
   10              0.000408   let cwd = getcwd()
   10              0.000843   execute cdcmd . current_path
   10   0.004722   0.000104   if s:Process.has_vimproc()
   10   0.142916   0.000227     let toplevel_path = vimproc#system('git --no-pager rev-parse --show-toplevel')
   10   0.000081   0.000056     let has_error = vimproc#get_last_status() != 0
   10              0.000006   else
                                let toplevel_path = system('git --no-pager rev-parse --show-toplevel')
                                let has_error = v:shell_error != 0
                              endif
   10              0.002474   execute cdcmd . cwd
   10              0.000017   if has_error
                                throw 'Agit: Not a git repository.'
                              endif
   10   0.000378   0.000124   return s:String.chomp(toplevel_path) . '/.git'

FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
   10   8.232178   0.002220  agit#launch()
   10   7.778901   0.002763  agit#bufwin#agit_tabnew()
   10   7.670762   0.000130  18()
   10   7.670632   0.000086  20()
   10   7.670546   0.007161  21()
   10   7.646445   0.050495  7()
   90   6.849425   0.007429  vimproc#system()
   80   6.714214   0.006317  agit#git#exec()
   90   5.079636   0.025701  <SNR>30_system()
 1154   4.737808   4.618134  <SNR>30_libcall()
  221   4.727257   0.016046  <SNR>30_read_pgroup()
  221   4.670076   0.005321  <SNR>30_read_pipes()
  221   4.664755   0.019921  <SNR>30_read()
  700   4.644834   0.009479  <SNR>30_vp_pipe_read()
  700   4.635355   0.006348  <SNR>30_libcall_raw_read()
   20   2.823103   0.000830  10()
   90   1.351196   0.013663  vimproc#parser#parse_pipe()
   10   1.172683   0.385697  agit#aligner#align()
 5000   0.649529   0.032434  <SNR>42_fillncate()
 5000   0.581492   0.111336  agit#string#truncate()
```