### PR TITLE
fix fugitive command registration

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -79,8 +79,7 @@ function! agit#launch(args)
     call agit#bufwin#agit_tabnew(git)
     let t:git = git
     if s:fugitive_enabled
-      let b:git_dir = git_dir " for fugitive commands
-      silent doautocmd User Fugitive
+      call fugitive#detect(git_dir)
     endif
   catch /Agit: /
     echohl ErrorMsg | echomsg v:exception | echohl None


### PR DESCRIPTION
After this change, "au User Fugitive" no longer registers fugitive's commands.
https://github.com/tpope/vim-fugitive/pull/792

