### PR TITLE
[WIP] Make enable to pass revisions to :AgitDiff

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -174,32 +174,17 @@ function! agit#reload() abort
   endtry
 endfunction
 
-function! agit#diff() abort
+function! agit#diff(args) abort
   try
     if !exists('t:git')
       return
-    endif
-    let rhash = t:git.hash
-    if rhash ==# 'nextpage'
-      return
-    elseif rhash ==# 'unstaged'
-      let lhash = 'staged'
-    elseif rhash ==# 'staged'
-      let lhash = s:String.chomp(agit#git#exec('rev-parse --short HEAD', t:git.git_dir))
-    else
-      let lhash = s:String.chomp(agit#git#exec('rev-parse --short ' . rhash . '~1', t:git.git_dir))
     endif
     if &filetype ==# 'agit'
       let relpath = t:git.relpath
     else
       let relpath = expand('<cfile>')
     endif
-    let hash = (rhash ==# 'unstaged' || rhash ==# 'staged' ? 'HEAD' : rhash)
-    if agit#git#exec('ls-tree --name-only "' . hash . '" -- "' . t:git.to_abspath(relpath) . '"', t:git.git_dir) == ''
-      throw "Agit: File not tracked: " . relpath
-    endif
-
-    call agit#diff#sidebyside(t:git, relpath, lhash, rhash)
+    call agit#diff#sidebyside(t:git, relpath, a:args)
   catch /Agit: /
     echohl ErrorMsg | echomsg v:exception | echohl None
   endtry

--- a/autoload/agit/diff.vim
+++ b/autoload/agit/diff.vim
@@ -1,8 +1,98 @@
-function! agit#diff#sidebyside(git, relpath, lhash, rhash) abort
+function! agit#diff#revision_list(git)
+  " TODO: this function should be unified with agit#revision_list
+  let revs = split(agit#git#exec('rev-parse --symbolic --branches --remotes --tags', a:git.git_dir), "\n")
+        \  + ['HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'FETCH_HEAD', 'staged', 'unstaged']
+  if a:git.hash =~# '^\x\{7\}$'
+    let revs = insert(revs, a:git.hash)
+  endif
+  return revs
+endfunction
+
+let s:revspec_pattern = '\v^(.{-})%((\.{2,3})(.*))?$'
+
+function! agit#diff#complete_revspec(arglead, ...)
+  " return revision specification candidates (provide completion for AgitDiff)
+  " revision specification patterns are 'R1', 'R1..R2', and 'R1...R2'
+  if !exists('t:git')
+    return []
+  endif
+  let matches = matchlist(a:arglead, s:revspec_pattern)
+  let [rev1, dots, rev2] = matches[1:3]
+  let revs = agit#diff#revision_list(t:git)
+  if empty(dots)
+    return filter(revs, 'stridx(v:val, rev1) == 0')
+  else
+    return map(filter(revs, 'stridx(v:val, rev2) == 0'), 'rev1 . dots . v:val')
+  endif
+endfunction
+
+function! s:replace_keyword(git, rev)
+  if a:rev ==# ''
+    return 'HEAD'
+  elseif a:rev ==# '<hash>'
+    if a:git.hash ==# 'nextpage'
+      throw 'Agit: Commit is not selected'
+    endif
+    return a:git.hash
+  else
+    return a:rev
+  endif
+endfunction
+
+function! s:get_parent_hash(git, rev)
+  if a:rev ==# 'unstaged'
+    let rev = 'staged'
+  elseif a:rev ==# 'staged'
+    let rev = 'HEAD'
+  else
+    let rev = a:rev . '~'
+  endif
+  return a:git.get_shorthash(rev)
+endfunction
+
+function! agit#diff#get_target_hashes(git, revspec)
+  let matches = matchlist(a:revspec, s:revspec_pattern)
+  let [rev1, dots, rev2] = matches[1:3]
+  if empty(dots)
+    if empty(rev1)
+      " No revisions specified
+      " show changes create by current revision
+      let rhash = a:git.get_shorthash(s:replace_keyword(a:git, '<hash>'))
+      return [s:get_parent_hash(a:git, rhash), rhash]
+    else
+      " Single revision specified
+      " show changes between specified revision and workingtree
+      let rhash = a:git.get_shorthash(s:replace_keyword(a:git, rev1))
+      return [rhash, 'unstaged']
+    endif
+  else
+    let rev1 = s:replace_keyword(a:git, rev1)
+    let rev2 = s:replace_keyword(a:git, rev2)
+    if dots == '..'
+      " Two revisions specified with double dots (A..B)
+      " show changes between A and B
+      return [a:git.get_shorthash(rev1), a:git.get_shorthash(rev2)]
+    else
+      " Two revisions specified with triple dots (A...B)
+      " show changes between merge-base(common ancestor of A and B) and B
+      return [a:git.get_mergebase(rev1, rev2), a:git.get_shorthash(rev2)]
+    endif
+  endif
+endfunction
+
+function! agit#diff#sidebyside(git, relpath, revspec) abort
+  let [lhash, rhash] = agit#diff#get_target_hashes(a:git, a:revspec)
+  if lhash ==# rhash
+    throw "Agit: Specified revisions indicate same commit"
+  endif
+  let hash = (rhash ==# 'unstaged' || rhash ==# 'staged' ? 'HEAD' : rhash)
+  if agit#git#exec('ls-tree --name-only "' . hash . '" -- "' . a:git.to_abspath(a:relpath) . '"', a:git.git_dir) == ''
+    throw "Agit: File not tracked: " . a:relpath
+  endif
   tabnew
-  call s:fill_buffer(a:git, a:relpath, a:lhash)
+  call s:fill_buffer(a:git, a:relpath, lhash)
   botright vnew
-  call s:fill_buffer(a:git, a:relpath, a:rhash)
+  call s:fill_buffer(a:git, a:relpath, rhash)
   windo diffthis
 endfunction
 

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -166,6 +166,21 @@ function! s:git.commitmsg(hash) dict
   return agit#git#exec('show -s --format=format:%s ' . a:hash, self.git_dir)
 endfunction
 
+function! s:git.get_mergebase(rev1, rev2)
+  let rev1 = a:rev1 =~# '^\(un\)\?staged$' ? 'HEAD' : a:rev1
+  let rev2 = a:rev2 =~# '^\(un\)\?staged$' ? 'HEAD' : a:rev2
+  return s:String.chomp(agit#git#exec_or_die('merge-base "' . rev1 . '" "' . rev2 . '"', t:git.git_dir))
+endfunction
+
+function! s:git.get_shorthash(revspec)
+  if a:revspec =~# '^\(un\)\?staged$'
+    return a:revspec
+  elseif a:revspec =~# '^\x\{7,\}$'
+    return a:revspec[:6]
+  endif
+  return s:String.chomp(agit#git#exec_or_die('rev-parse --short "' . a:revspec . '"', t:git.git_dir))
+endfunction
+
 let s:seq = ''
 function! agit#git#new(git_dir)
   let git = extend(deepcopy(s:git), {'git_dir' : a:git_dir, 'seq': s:seq})

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -196,6 +196,17 @@ function! agit#git#exec(command, git_dir, ...)
   endif
 endfunction
 
+function! agit#git#exec_or_die(command, git_dir)
+  let ret = agit#git#exec(a:command, a:git_dir)
+  if s:last_status == 0
+    return ret
+  else
+    let command_name = matchstr(a:command, '^\S\+')
+    let error = substitute(ret, '[\r\n].*', '', 'g')
+    throw 'Agit: git ' . command_name . ' failed(' . string(s:last_status) . '). ' . error
+  endif
+endfunction
+
 function! agit#git#get_last_status()
   return s:last_status
 endfunction

--- a/autoload/agit/view/filelog.vim
+++ b/autoload/agit/view/filelog.vim
@@ -7,6 +7,7 @@ function! agit#view#filelog#new(git)
   command! -buffer -nargs=? -complete=customlist,agit#diff#complete_revspec AgitDiff call agit#diff(<q-args>)
   if !g:agit_no_default_mappings
     nmap <silent><buffer> di <Plug>(agit-diff)
+    nmap <silent><buffer> dl <Plug>(agit-diff-with-local)
   endif
   return filelog
 endfunction

--- a/autoload/agit/view/filelog.vim
+++ b/autoload/agit/view/filelog.vim
@@ -4,7 +4,7 @@ let s:filelog = {
 
 function! agit#view#filelog#new(git)
   let filelog = extend(agit#view#log#new(a:git), s:filelog)
-  command! -buffer AgitDiff call agit#diff()
+  command! -buffer -nargs=? -complete=customlist,agit#diff#complete_revspec AgitDiff call agit#diff(<q-args>)
   if !g:agit_no_default_mappings
     nmap <silent><buffer> di <Plug>(agit-diff)
   endif

--- a/autoload/agit/view/stat.vim
+++ b/autoload/agit/view/stat.vim
@@ -33,8 +33,8 @@ function! s:stat.setlocal()
   setlocal nocursorline nocursorcolumn
   setlocal winfixheight
   setlocal noswapfile
-  command! -buffer AgitDiff call agit#diff()
-
+  command! -buffer -nargs=? -complete=customlist,agit#diff#complete_revspec AgitDiff call agit#diff(<q-args>)
+  nmap <buffer> q <Plug>(agit-exit)
   if !g:agit_no_default_mappings
     nmap <silent><buffer> u <PLug>(agit-reload)
     nmap <silent><buffer> <C-j> <Plug>(agit-scrolldown-diff)

--- a/autoload/agit/view/stat.vim
+++ b/autoload/agit/view/stat.vim
@@ -42,6 +42,7 @@ function! s:stat.setlocal()
     nmap <silent><buffer> q <Plug>(agit-exit)
 
     nmap <silent><buffer> di <Plug>(agit-diff)
+    nmap <silent><buffer> dl <Plug>(agit-diff-with-local)
   endif
   set filetype=agit_stat
 endfunction

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -123,8 +123,9 @@ COMMANDS					*agit-commands*
 	(Same as |fugitive|'s |:Git|)
 
 						*:AgitDiff*
-:AgitDiff
-	Show |vimdiff| against the target file of the current revision.
+:AgitDiff [{revisions}]
+	Show |vimdiff| against the target file.
+	AgitDiff accepts target revision(s) as an argument.
 	Note: This command is available only in |agit-log| buffer from
 	|:AgitFile| and |agit-stat| buffer.
 
@@ -135,6 +136,26 @@ COMMANDS					*agit-commands*
 
 	If you installed |fugitive|, AgitDiff uses |fugitive| when showing staged
 	file. This means you can stage or unstage each hunks like |:Gdiff|.
+
+						*agit-diff-revspec*
+	revisions can be specified by almost same way as "git diff".
+	For example:
+
+	:AgitDiff (No revision specified)
+	show changes made by current revision
+
+	:AgitDiff REV1
+	show changes between REV1 and local
+
+	:AgitDiff REV1..REV2
+	show changes between REV1 and REV2
+
+	:AgitDiff REV1...REV2
+	show changes between marge_base(REV1, REV2) and REV2
+	marge_base(REV1, REV2) means "newest common ancestor of REV1 and REV2"
+
+	:AgitDiff REV1..
+	show changes between REV1 and HEAD ("HEAD" can be omitted)
 
 ------------------------------------------------------------------------------
 KEY-MAPPINGS					*agit-key-mappings*
@@ -216,6 +237,11 @@ Available only in |agit-log| buffer unless explicitly mentioned.
 	Show |vimdiff| against the target file of the current revision.
 	Availabie in |agit-log|, |agit-stat|
 
+<Plug>(agit-diff-with-local)			*<Plug>(agit-diff-with-local)*
+	Show |vimdiff| against the target file changes between current
+	revision and local.
+	Availabie in |agit-log|, |agit-stat|
+
 
 ------------------------------------------------------------------------------
 DEFAULT KEY-MAPPINGS				*agit-default-key-mappings*
@@ -237,6 +263,7 @@ rh			<Plug>(agit-git-reset-hard)
 rb			<Plug>(agit-git-rebase)
 ri			<Plug>(agit-git-rebase-i)
 di			<Plug>(agit-diff)
+dl			<Plug>(agit-diff-with-local)
 
 ------------------------------------------------------------------------------
 VARIABLES					*agit-variables*

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -44,6 +44,7 @@ nnoremap <silent> <PLug>(agit-yank-hash) :<C-u>call agit#yank_hash()<CR>
 nnoremap <silent> <Plug>(agit-show-commit) :<C-u>call agit#show_commit()<CR>
 nnoremap <silent> <Plug>(agit-print-commitmsg) :<C-u>call agit#print_commitmsg()<CR>
 nnoremap <silent> <Plug>(agit-diff) :<C-u>AgitDiff<CR>
+nnoremap <silent> <Plug>(agit-diff-with-local) :<C-u>AgitDiff <hash><CR>
 
 nnoremap <silent> <Plug>(agit-git-checkout)     :<C-u>AgitGit checkout <branch><CR>
 nnoremap <silent> <Plug>(agit-git-checkout-b)   :<C-u>AgitGit checkout -b \%# <hash><CR>


### PR DESCRIPTION
Make enable to pass revisions to AgitDiff

```
:AgitDiff
  show diff created by selected commit

:AgitDiff REV
  show diff between REV and local

:AgitDiff <hash>
  show diff between selected commit and working copy
  ("<hash>" is replaced by hash of selected commit)

:AgitDiff REV1..REV2
  show diff between REV1 and REV2

:AgitDiff REV..
  show diff between REV and HEAD

:AgitDiff REV1...REV2
  show diff between merge_base(REV1, REV2) and REV2
```

AgitDiffを、git diffと同じ形式でリビジョンを指定できるようにしています。
とりあえずコマンドの修正だけをしていますが、これでOKならREADME、docの修正と「ローカルと比較」のキーバインディングの設定などを追加したいと思います。
