### PR TITLE
Fix side by side diff

### DIFF
--- a/autoload/agit/diff.vim
+++ b/autoload/agit/diff.vim
@@ -98,7 +98,7 @@ endfunction
 
 function! s:fill_buffer(git, relpath, hash) abort
   if a:hash ==# 'unstaged'
-    edit! `=a:git.filepath`
+    edit! `=a:git.to_abspath(a:relpath)`
   elseif a:hash ==# 'staged' && get(g:, 'loaded_fugitive', 0)
     edit! `='fugitive://' . a:git.git_root . '.git//0/' . a:relpath`
   else

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -148,12 +148,16 @@ function! s:git.diff(hash) dict
   return diff
 endfunction
 
+function! s:git.to_abspath(relpath)
+  return self.git_root . '/' . a:relpath
+endfunction
+
 function! s:git.catfile(hash, path)
-  let relpath = self.relpath()
+  let relpath = s:String.chomp(agit#git#exec('ls-tree --full-name --name-only HEAD ''' . a:path . '''', self.git_root))
   if a:hash == 'nextpage'
     let catfile = ''
   elseif a:hash == 'unstaged'
-    let catfile = join(readfile(a:path), "\n")
+    let catfile = join(readfile(self.to_abspath(a:path)), "\n")
   elseif a:hash == 'staged'
     let catfile = agit#git#exec('cat-file -p ":' . relpath . '"', self.git_root)
   else


### PR DESCRIPTION
AgitDiffが正しく動かなくなっていたのを修正しました。

引数で受け取ったパスに対して処理する必要のあるメソッドでgit.filepath や git.relpath() に対して処理していたため、どのファイルを指定しても同じファイルのdiffが表示される状態になっていました