### PR TITLE
Fix AgitFile error

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -157,7 +157,7 @@ function! s:git.catfile(hash, path)
   if a:hash == 'nextpage'
     let catfile = ''
   elseif a:hash == 'unstaged'
-    let catfile = join(readfile(self.to_abspath(a:path)), "\n")
+    let catfile = join(readfile(a:path), "\n")
   elseif a:hash == 'staged'
     let catfile = agit#git#exec('cat-file -p ":' . relpath . '"', self.git_root)
   else


### PR DESCRIPTION
変更されたバッファで`AgitFile`を実行すると、Can't open file ~.というようなエラーが出力されていました。

前の処理に戻すことで対応致しました。

unstaged時に、self.to_abspathで存在しないファイルパスが生成されている状態が原因でした。

よろしくお願いします。