### PR TITLE
Fix "cd" to repository root on Windows

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -201,7 +201,7 @@ function! agit#git#exec(command, git_root, ...)
     execute '!' . cmd
   else
     if s:Process.has_vimproc()
-      let ret = vimproc#system(cmd)
+      let ret = vimproc#cmd#system(cmd)
       let s:last_status = vimproc#get_last_status()
     else
       let ret = system(cmd)


### PR DESCRIPTION
Suppress `[vimproc] vimproc#get_command_name: File "cd" is not found.`

477d49af31f8b0b464bd24deaa154f6ab5f89a4c の変更で、Windows でリポジトリのルートの設定に失敗して `[vimproc] vimproc#get_command_name: File "cd" is not found.` と出るようになったのを直しました。
