### PR TITLE
Revert "fix path issue on `ls-tree` on Windows"

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -30,7 +30,7 @@ let s:git = {
 
 function! s:git.relpath() abort
   if !has_key(self, '_relpath')
-    let self._relpath = s:String.chomp(agit#git#exec('ls-tree --full-name --name-only HEAD "' . self.filepath . '"', self.git_root))
+    let self._relpath = s:String.chomp(agit#git#exec('ls-tree --full-name --name-only HEAD ''' . self.filepath . '''', self.git_root))
   endif
   return self._relpath
 endfunction
@@ -153,7 +153,7 @@ function! s:git.to_abspath(relpath)
 endfunction
 
 function! s:git.catfile(hash, path)
-  let relpath = s:String.chomp(agit#git#exec('ls-tree --full-name --name-only HEAD "' . a:path . '"', self.git_root))
+  let relpath = s:String.chomp(agit#git#exec('ls-tree --full-name --name-only HEAD ''' . a:path . '''', self.git_root))
   if a:hash == 'nextpage'
     let catfile = ''
   elseif a:hash == 'unstaged'
@@ -196,7 +196,7 @@ endfunction
 let s:last_status = 0
 let s:is_cp932 = &enc == 'cp932'
 function! agit#git#exec(command, git_root, ...)
-  let cmd = 'cd "' . a:git_root . '" && git --no-pager ' . a:command
+  let cmd = 'git --no-pager -C "' . a:git_root . '" ' . a:command
   if a:0 > 0 && a:1 == 1
     execute '!' . cmd
   else


### PR DESCRIPTION
This PR causes some issue reported on #78.

#78 summary

- This PR uses `cd` command but some linux distribution doesn't have `cd` as a command.
- #77 does't fix this issue.