### PR TITLE
add g:agit_log_width

### DIFF
--- a/autoload/agit/view/log.vim
+++ b/autoload/agit/view/log.vim
@@ -30,7 +30,7 @@ function! s:log.renderwith(funcname)
         \ 'unstaged' : self.git.unstaged.line > 0
         \ }
   call agit#bufwin#move_to(self.name)
-  call s:fill_buffer(self.git[a:funcname](winwidth(0)))
+  call s:fill_buffer(self.git[a:funcname](g:agit_log_width <= 0 ? winwidth(0) : g:agit_log_width))
   if empty(save.hash)
     call self.emmit(1)
   else

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -306,6 +306,10 @@ g:agit_ignore_spaces				*g:agit_ignore_spaces*
 	|agit-diff| and |agit-stat| buffer.
 	default value: 1
 
+g:agit_log_width				*g:agit_log_width*
+	Max columns of |agit-log| buffer, zero to use window width.
+	default value: 0
+
 g:agit_stat_width				*g:agit_stat_width*
 	Max columns of |agit-stat| buffer.
 	default value: 80

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -27,6 +27,9 @@ endif
 if !exists('g:agit_ignore_spaces')
     let g:agit_ignore_spaces = 1
 endif
+if !exists('g:agit_log_width')
+    let g:agit_log_width = 0
+endif
 if !exists('g:agit_stat_width')
     let g:agit_stat_width = 80
 endif


### PR DESCRIPTION
similar to `g:agit_stat_width`, allow user to customize the `agit log` window width

why? the commit date and username holds too much space causing commit msg has little space to show, especially for small displays, similar issue: #17 