### PR TITLE
implement a new option to truncate the author name in agit-log buffer

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -35,9 +35,13 @@ function! s:git.relpath() abort
   return self._relpath
 endfunction
 
+function! s:get_author_name_format()
+  return '{>' . (g:agit_max_author_name_width > 0 ? '%<(' . g:agit_max_author_name_width . ',trunc)' : '') . '%an<}'
+endfunction
+
 function! s:git.log(winwidth) dict
   let max_count = g:agit_max_log_lines + 1
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]"', self.git_root)
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . s:get_author_name_format() . s:sep . '[%h]"', self.git_root)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')
@@ -67,7 +71,7 @@ endfunction
 
 function! s:git.filelog(winwidth)
   let max_count = g:agit_max_log_lines + 1
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . '{>%an<}' . s:sep . '[%h]" -- "' . self.filepath . '"', self.git_root)
+  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . s:get_author_name_format() . s:sep . '[%h]" -- "' . self.filepath . '"', self.git_root)
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -290,6 +290,11 @@ g:agit_max_log_lines				*g:agit_max_log_lines*
 	Large value is useful to explore the very old history but it causes
 	less performance.
 	default value: 500
+	
+g:agit_max_author_name_width			*g:agit_max_author_name_width*
+	If it is non-zero, the commit author names in |agit-log| buffer are
+	truncated to the value.
+	default value: 0
 
 g:agit_skip_empty_line				*g:agit_skip_empty_line*
 	If it is non-zero, empty lines are skipped when you move the cursor in

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -18,6 +18,9 @@ endif
 if !exists('g:agit_max_log_lines')
   let g:agit_max_log_lines = 500
 endif
+if !exists('g:agit_max_author_name_width')
+  let g:agit_max_author_name_width = 0
+endif
 if !exists('g:agit_skip_empty_line')
   let g:agit_skip_empty_line = 1
 endif


### PR DESCRIPTION
This pull request introduces a new option to truncate the author names. I don't change the default behavior.

Example screenshots: (`let agit_max_author_name_width = 13`)

|before|after|
|--|--|
|<img width="922" alt="Screen Shot 2019-12-04 at 11 42 27" src="https://user-images.githubusercontent.com/375258/70107985-7193d380-168b-11ea-887f-cbd7d569e46b.png">|<img width="851" alt="Screen Shot 2019-12-04 at 11 43 46" src="https://user-images.githubusercontent.com/375258/70108026-9425ec80-168b-11ea-99ca-c6637ab5f95f.png">|