### PR TITLE
fix for initialized directory

### DIFF
--- a/autoload/agit/aligner.vim
+++ b/autoload/agit/aligner.vim
@@ -5,6 +5,10 @@ let s:List = agit#vital().List
 " table: [[String]] 2-dimensional string list
 " max_col: Integer if a one log exceeds max_col, be trimmed.
 function! agit#aligner#align(table, max_col, ...)
+  if empty(a:table)
+    return []
+  endif
+
   let column_number = len(a:table[0]) " sampling head's column number
 
   let maxs = []

--- a/test/aligner.vim
+++ b/test/aligner.vim
@@ -37,3 +37,10 @@ function! s:suite.aligns_fields_within_limited_columns()
   \ ]
   call Expect(aligned).to_equal(expect)
 endfunction
+
+function! s:suite.aligns_empty_log()
+  let logs = []
+  let aligned = agit#aligner#align(logs, 56)
+  let expect = []
+  call Expect(aligned).to_equal(expect)
+endfunction


### PR DESCRIPTION
Hi :) This pull request fixes :Agit for the directory just after `git init`.

Reproducing steps.
```
cd $(mktemp -d)
git init
echo 'hello world' > README.md
git add README.md
vim
:Agit
```

Errors
```
Error detected while processing function
agit#launch[29]..agit#bufwin#agit_tabnew[6]..20[2]..22[1]..23[8]..8[10]..agit#aligner#align:
line    1:
E684: list index out of range: 0
E116: Invalid arguments for function len(a:table[0]) " sampling head's column number
```

I use your plugin everyday and love it!