### PR TITLE
Replace fugitive#detect with FugitiveDetect which is a new public API

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -78,7 +78,7 @@ function! agit#launch(args)
     call agit#bufwin#agit_tabnew(git)
     let t:git = git
     if s:fugitive_enabled
-      call fugitive#detect(git_root . '/.git')
+      call FugitiveDetect(git_root . '/.git')
     endif
   catch /Agit: /
     echohl ErrorMsg | echomsg v:exception | echohl None


### PR DESCRIPTION
Recently, fugitive is going to deprecate some autoload functions (see https://github.com/tpope/vim-fugitive/commit/cd7db1d57cc991b27d9c9ce6552faea3075ada61). I got the following error with the latest fugitive.
```
Error detected while processing function agit#launch[32]..fugitive#detect:
line    1:
E605: Exception not caught: Third party code is using fugitive#detect() which has been removed. Contact the author if you have a reason to still use it
```
Easy fix is to replace `fugitive#detect` with `FugitiveDetect` (e.x. https://github.com/junegunn/gv.vim/commit/72dc64df998355b41a75ebfa32adfd08ed5c5819)