### PR TITLE
fix "Agit: File not tracked: %" error in AgitFile

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -193,7 +193,7 @@ function s:get_git_root(basedir)
   if empty(a:basedir)
     " if fugitive exists
     if s:fugitive_enabled && exists('b:git_dir')
-      return matchstr(b:git_dir, '^.\+\ze\.git')
+      return FugitiveWorkTree()
     else
       let current_path = expand('%:p:h')
     endif


### PR DESCRIPTION
If fugitive is available, `s:get_git_root()` returns path with .git removed from GitDir. That path is passed to the `git -C` option, but `-C` must specify the ROOT PATH where `.git` resides, not GitDir.

Use `FugitiveWorkTree()` instead of `b:git_dir` Fugitive's variable. `FugitiveWorkTree()` seems to return the intended GIT ROOT even in directories checked out by `git worktree add`
