### PR TITLE
Apply colorful tree syntax

### DIFF
--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -1,4 +1,4 @@
-if exists("b:current_syntax")
+if exists('b:current_syntax')
   finish
 endif
 
@@ -47,7 +47,7 @@ hi def link agitDateMark Ignore
 hi def link agitAuthorMark Ignore
 hi def link agitTree0 Constant
 
-if &background == "dark"
+if &background ==# 'dark'
   hi default agitTree1 ctermfg=magenta     guifg=green1
   hi default agitTree2 ctermfg=green       guifg=yellow1
   hi default agitTree3 ctermfg=yellow      guifg=orange1
@@ -69,4 +69,4 @@ else
   hi default agitTree9 ctermfg=darkmagenta guifg=darkviolet
 endif
 
-let b:current_syntax = "agit"
+let b:current_syntax = 'agit'

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -23,6 +23,8 @@ syn match agitAuthorMark /<}/ contained conceal
 
 let s:tree_chars = '|/\\*_\-.'
 let s:tree_pat = '/['. s:tree_chars .']\{-}\zs[ '. s:tree_chars .']/'
+" Keep to define syntax in the reverse order to apply from 0 to 9; otherwise,
+" applied from 9 to 0. Syntax are applied from later defined ones to former.
 exe 'syn match agitTree9' s:tree_pat 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
 exe 'syn match agitTree8' s:tree_pat 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
 exe 'syn match agitTree7' s:tree_pat 'nextgroup=agitTree8,agitRef,agitLog skipwhite'

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -21,19 +21,21 @@ syn match agitAuthorMark /{>/ contained conceal
 syn match agitAuthorMark /<}/ contained conceal
 
 let s:tree_chars = '|/\\*_\-.'
-let s:tree_pat = '/[ '. s:tree_chars .']\{-}\zs['. s:tree_chars .']\s\=/'
+let s:tree_pat_preceding = '['. s:tree_chars .' ]\{-}\zs'
+let s:tree_pat_target = '['. s:tree_chars .']\s\='
+let s:tree_pattern = '/'. s:tree_pat_preceding . s:tree_pat_target .'/'
 " Keep to define syntax in the reverse order to apply from 0 to 9; otherwise,
 " applied from 9 to 0. Syntax are applied from later defined ones to former.
-exe 'syn match agitTree9' s:tree_pat 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
-exe 'syn match agitTree8' s:tree_pat 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
-exe 'syn match agitTree7' s:tree_pat 'nextgroup=agitTree8,agitRef,agitLog skipwhite'
-exe 'syn match agitTree6' s:tree_pat 'nextgroup=agitTree7,agitRef,agitLog skipwhite'
-exe 'syn match agitTree5' s:tree_pat 'nextgroup=agitTree6,agitRef,agitLog skipwhite'
-exe 'syn match agitTree4' s:tree_pat 'nextgroup=agitTree5,agitRef,agitLog skipwhite'
-exe 'syn match agitTree3' s:tree_pat 'nextgroup=agitTree4,agitRef,agitLog skipwhite'
-exe 'syn match agitTree2' s:tree_pat 'nextgroup=agitTree3,agitRef,agitLog skipwhite'
-exe 'syn match agitTree1' s:tree_pat 'nextgroup=agitTree2,agitRef,agitLog skipwhite'
-exe 'syn match agitTree0' s:tree_pat 'nextgroup=agitTree1,agitRef,agitLog skipwhite'
+exe 'syn match agitTree9' s:tree_pattern 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
+exe 'syn match agitTree8' s:tree_pattern 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
+exe 'syn match agitTree7' s:tree_pattern 'nextgroup=agitTree8,agitRef,agitLog skipwhite'
+exe 'syn match agitTree6' s:tree_pattern 'nextgroup=agitTree7,agitRef,agitLog skipwhite'
+exe 'syn match agitTree5' s:tree_pattern 'nextgroup=agitTree6,agitRef,agitLog skipwhite'
+exe 'syn match agitTree4' s:tree_pattern 'nextgroup=agitTree5,agitRef,agitLog skipwhite'
+exe 'syn match agitTree3' s:tree_pattern 'nextgroup=agitTree4,agitRef,agitLog skipwhite'
+exe 'syn match agitTree2' s:tree_pattern 'nextgroup=agitTree3,agitRef,agitLog skipwhite'
+exe 'syn match agitTree1' s:tree_pattern 'nextgroup=agitTree2,agitRef,agitLog skipwhite'
+exe 'syn match agitTree0' s:tree_pattern 'nextgroup=agitTree1,agitRef,agitLog skipwhite'
 
 hi def link agitLog Normal
 hi def link agitHead Special

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -48,25 +48,25 @@ hi def link agitDateMark Ignore
 hi def link agitAuthorMark Ignore
 
 if &background == "dark"
-  highlight default agitTree1 ctermfg=magenta     guifg=green1
-  highlight default agitTree2 ctermfg=green       guifg=yellow1
-  highlight default agitTree3 ctermfg=yellow      guifg=orange1
-  highlight default agitTree4 ctermfg=cyan        guifg=greenyellow
-  highlight default agitTree5 ctermfg=red         guifg=springgreen1
-  highlight default agitTree6 ctermfg=yellow      guifg=cyan1
-  highlight default agitTree7 ctermfg=green       guifg=slateblue1
-  highlight default agitTree8 ctermfg=cyan        guifg=magenta1
-  highlight default agitTree9 ctermfg=magenta     guifg=purple1
+  hi default agitTree1 ctermfg=magenta     guifg=green1
+  hi default agitTree2 ctermfg=green       guifg=yellow1
+  hi default agitTree3 ctermfg=yellow      guifg=orange1
+  hi default agitTree4 ctermfg=cyan        guifg=greenyellow
+  hi default agitTree5 ctermfg=red         guifg=springgreen1
+  hi default agitTree6 ctermfg=yellow      guifg=cyan1
+  hi default agitTree7 ctermfg=green       guifg=slateblue1
+  hi default agitTree8 ctermfg=cyan        guifg=magenta1
+  hi default agitTree9 ctermfg=magenta     guifg=purple1
 else
-  highlight default agitTree1 ctermfg=darkyellow  guifg=orangered3
-  highlight default agitTree2 ctermfg=darkgreen   guifg=orange2
-  highlight default agitTree3 ctermfg=blue        guifg=yellow3
-  highlight default agitTree4 ctermfg=darkmagenta guifg=olivedrab4
-  highlight default agitTree5 ctermfg=red         guifg=green4
-  highlight default agitTree6 ctermfg=darkyellow  guifg=paleturquoise3
-  highlight default agitTree7 ctermfg=darkgreen   guifg=deepskyblue4
-  highlight default agitTree8 ctermfg=blue        guifg=darkslateblue
-  highlight default agitTree9 ctermfg=darkmagenta guifg=darkviolet
+  hi default agitTree1 ctermfg=darkyellow  guifg=orangered3
+  hi default agitTree2 ctermfg=darkgreen   guifg=orange2
+  hi default agitTree3 ctermfg=blue        guifg=yellow3
+  hi default agitTree4 ctermfg=darkmagenta guifg=olivedrab4
+  hi default agitTree5 ctermfg=red         guifg=green4
+  hi default agitTree6 ctermfg=darkyellow  guifg=paleturquoise3
+  hi default agitTree7 ctermfg=darkgreen   guifg=deepskyblue4
+  hi default agitTree8 ctermfg=blue        guifg=darkslateblue
+  hi default agitTree9 ctermfg=darkmagenta guifg=darkviolet
 endif
 
 let b:current_syntax = "agit"

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -5,7 +5,6 @@ endif
 syn cluster agitLogFields contains=agitDate,agitAuthor,agitHash
 syn cluster agitRefs contains=agitHead,agitBranch,agitRemote,agitTag
 
-hi def link agitTree0 Constant
 syn match agitLog /.*/ contained contains=@agitLogFields
 
 syn region agitRef start="(" end=")" end="\.\.\." contained contains=@agitRefs nextgroup=agitLog keepend
@@ -46,6 +45,7 @@ hi def link agitAuthor Type
 hi def link agitHash Ignore
 hi def link agitDateMark Ignore
 hi def link agitAuthorMark Ignore
+hi def link agitTree0 Constant
 
 if &background == "dark"
   hi default agitTree1 ctermfg=magenta     guifg=green1

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -22,11 +22,9 @@ syn match agitAuthorMark /{>/ contained conceal
 syn match agitAuthorMark /<}/ contained conceal
 
 let s:tree_chars = '|/\\*_\-.'
-let s:tree_pat = '/['. s:tree_chars .']\{-}\zs[ '. s:tree_chars .']/'
+let s:tree_pat = '/[ '. s:tree_chars .']\{-}\zs['. s:tree_chars .']\s\=/'
 " Keep to define syntax in the reverse order to apply from 0 to 9; otherwise,
 " applied from 9 to 0. Syntax are applied from later defined ones to former.
-" TODO: apply the same syntax color on either '\' and '/' as the next char
-"   which is one in '|*_\-.'.
 exe 'syn match agitTree9' s:tree_pat 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
 exe 'syn match agitTree8' s:tree_pat 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
 exe 'syn match agitTree7' s:tree_pat 'nextgroup=agitTree8,agitRef,agitLog skipwhite'

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -5,7 +5,7 @@ endif
 syn cluster agitLogFields contains=agitDate,agitAuthor,agitHash
 syn cluster agitRefs contains=agitHead,agitBranch,agitRemote,agitTag
 
-syn match agitTree /^[|/\\* _\-.]\+/ nextgroup=agitRef,agitLog
+hi def link agitTree0 Constant
 syn match agitLog /.*/ contained contains=@agitLogFields
 
 syn region agitRef start="(" end=")" end="\.\.\." contained contains=@agitRefs nextgroup=agitLog keepend
@@ -21,7 +21,19 @@ syn match agitDateMark /<|/ contained conceal
 syn match agitAuthorMark /{>/ contained conceal
 syn match agitAuthorMark /<}/ contained conceal
 
-hi def link agitTree Constant
+let s:tree_chars = '|/\\*_\-.'
+let s:tree_pat = '/['. s:tree_chars .']\{-}\zs[ '. s:tree_chars .']/'
+exe 'syn match agitTree9' s:tree_pat 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
+exe 'syn match agitTree8' s:tree_pat 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
+exe 'syn match agitTree7' s:tree_pat 'nextgroup=agitTree8,agitRef,agitLog skipwhite'
+exe 'syn match agitTree6' s:tree_pat 'nextgroup=agitTree7,agitRef,agitLog skipwhite'
+exe 'syn match agitTree5' s:tree_pat 'nextgroup=agitTree6,agitRef,agitLog skipwhite'
+exe 'syn match agitTree4' s:tree_pat 'nextgroup=agitTree5,agitRef,agitLog skipwhite'
+exe 'syn match agitTree3' s:tree_pat 'nextgroup=agitTree4,agitRef,agitLog skipwhite'
+exe 'syn match agitTree2' s:tree_pat 'nextgroup=agitTree3,agitRef,agitLog skipwhite'
+exe 'syn match agitTree1' s:tree_pat 'nextgroup=agitTree2,agitRef,agitLog skipwhite'
+exe 'syn match agitTree0' s:tree_pat 'nextgroup=agitTree1,agitRef,agitLog skipwhite'
+
 hi def link agitLog Normal
 hi def link agitHead Special
 hi def link agitRef Directory
@@ -32,5 +44,27 @@ hi def link agitAuthor Type
 hi def link agitHash Ignore
 hi def link agitDateMark Ignore
 hi def link agitAuthorMark Ignore
+
+if &background == "dark"
+  highlight default agitTree1 ctermfg=magenta     guifg=green1
+  highlight default agitTree2 ctermfg=green       guifg=yellow1
+  highlight default agitTree3 ctermfg=yellow      guifg=orange1
+  highlight default agitTree4 ctermfg=cyan        guifg=greenyellow
+  highlight default agitTree5 ctermfg=red         guifg=springgreen1
+  highlight default agitTree6 ctermfg=yellow      guifg=cyan1
+  highlight default agitTree7 ctermfg=green       guifg=slateblue1
+  highlight default agitTree8 ctermfg=cyan        guifg=magenta1
+  highlight default agitTree9 ctermfg=magenta     guifg=purple1
+else
+  highlight default agitTree1 ctermfg=darkyellow  guifg=orangered3
+  highlight default agitTree2 ctermfg=darkgreen   guifg=orange2
+  highlight default agitTree3 ctermfg=blue        guifg=yellow3
+  highlight default agitTree4 ctermfg=darkmagenta guifg=olivedrab4
+  highlight default agitTree5 ctermfg=red         guifg=green4
+  highlight default agitTree6 ctermfg=darkyellow  guifg=paleturquoise3
+  highlight default agitTree7 ctermfg=darkgreen   guifg=deepskyblue4
+  highlight default agitTree8 ctermfg=blue        guifg=darkslateblue
+  highlight default agitTree9 ctermfg=darkmagenta guifg=darkviolet
+endif
 
 let b:current_syntax = "agit"

--- a/syntax/agit.vim
+++ b/syntax/agit.vim
@@ -25,6 +25,8 @@ let s:tree_chars = '|/\\*_\-.'
 let s:tree_pat = '/['. s:tree_chars .']\{-}\zs[ '. s:tree_chars .']/'
 " Keep to define syntax in the reverse order to apply from 0 to 9; otherwise,
 " applied from 9 to 0. Syntax are applied from later defined ones to former.
+" TODO: apply the same syntax color on either '\' and '/' as the next char
+"   which is one in '|*_\-.'.
 exe 'syn match agitTree9' s:tree_pat 'nextgroup=agitTree0,agitRef,agitLog skipwhite'
 exe 'syn match agitTree8' s:tree_pat 'nextgroup=agitTree9,agitRef,agitLog skipwhite'
 exe 'syn match agitTree7' s:tree_pat 'nextgroup=agitTree8,agitRef,agitLog skipwhite'


### PR DESCRIPTION
This feature is modeled on [gregsexton/gitv](https://github.com/gregsexton/gitv)

![colorful-tree-compressor](https://user-images.githubusercontent.com/46470475/73605532-dd8aad80-45e2-11ea-89d0-64a02d38018b.png)

P.S. Some commits are made after the screenshot.