### PR TITLE
Add ability to use arbitrary log formats

### DIFF
--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -12,6 +12,8 @@ let g:agit#git#nextpage_message = '(too many logs)'
 let s:git = {
 \ 'git_root' : '',
 \ 'filepath': '',
+\ 'bang': 0,
+\ 'bangargs': '',
 \ 'hash': '',
 \ 'oninit': [],
 \ 'onhashchange': [],
@@ -41,7 +43,15 @@ endfunction
 
 function! s:git.log(winwidth) dict
   let max_count = g:agit_max_log_lines + 1
-  let gitlog = agit#git#exec('log --all --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . s:get_author_name_format() . s:sep . '[%h]"', self.git_root)
+  let l:logcmd = 'log --graph --decorate=full --no-color --date=relative --max-count=' . max_count . ' --format=format:"%d %s' . s:sep . '|>%ad<|' . s:sep . s:get_author_name_format() . s:sep . '[%h]" '
+  if self.bang
+    let l:logcmd = logcmd . self.bangargs
+  else
+    let l:logcmd = logcmd . '--all'
+  endif
+
+  let gitlog = agit#git#exec(l:logcmd, self.git_root)
+
   " 16 means concealed symbol (4*2 + 2) + hash (7) - right eade margin (1)
   let max_width = a:winwidth + 16
   let gitlog = substitute(gitlog, '\<refs/heads/', '', 'g')

--- a/doc/agit.txt
+++ b/doc/agit.txt
@@ -102,6 +102,19 @@ COMMANDS					*agit-commands*
 	--dir={basedir}				*agit-option-dir*
 	Set the repository path to {basedir}.
 
+						*:Agit!*
+:Agit! [{options}]
+	Open a new Agit tab. Repository path is based on the current
+	directory. This command takes all the options that the `git log`
+	command can take.
+
+	It is different from the regular |:Agit| command in
+	that it does not use the option `--all` to the `git log` command. So
+	it will only show the history based on arguments passed, and not of
+	the entire repo. So for example, if no options are paseed, it will
+	show the history of the current branch, just like running `git log` in
+	your shell would do.
+
 						*:AgitFile*
 :AgitFile [{options}]
 	Similar to |:Agit| but trace only current file log.
@@ -328,7 +341,6 @@ g:agit_reuse_tab				*g:agit_reuse_tab*
 ==============================================================================
 TODO						*agit-todo*
 
-* Arbitrary log format
 * More performance by using |if_lua|
 * Pagination
 * Commit filtering

--- a/plugin/agit.vim
+++ b/plugin/agit.vim
@@ -68,7 +68,7 @@ nnoremap <silent> <Plug>(agit-git-cherry-pick)  :<C-u>AgitGit cherry-pick <hash>
 nnoremap <silent> <Plug>(agit-git-revert)       :<C-u>AgitGit revert <hash><CR>
 nnoremap <silent> <Plug>(agit-exit)             :<C-u>call agit#exit()<CR>
 
-command! -nargs=* -complete=customlist,agit#complete_command Agit call agit#launch(<q-args>)
+command! -bang -nargs=* -complete=customlist,agit#complete_command Agit call agit#launch(<bang>0, <q-args>)
 command! -nargs=* -complete=customlist,agit#complete_command AgitFile Agit file <args>
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Add a new version of the :Agit command called :Agit! that takes arbitrary git-log arguments. This lets people use various options in git-log like -L, --authot, pathspecs, etc.

The implementation is a bit hacky but works for me.