### PR TITLE
Reduce potential problems

### DIFF
--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -76,7 +76,7 @@ function! agit#launch(args)
       endfor
     endif
     call agit#bufwin#agit_tabnew(git)
-    let t:git = git
+    let t:agit_git = git
     if s:fugitive_enabled
       call FugitiveDetect(git_root . '/.git')
     endif
@@ -107,7 +107,7 @@ endfunction
 function! agit#print_commitmsg()
   let hash = agit#extract_hash(getline('.'))
   if hash != ''
-    echo t:git.commitmsg(hash)
+    echo t:agit_git.commitmsg(hash)
   else
     echo
   endif
@@ -135,7 +135,7 @@ function! agit#yank_hash()
 endfunction
 
 function! agit#exit()
-  if !exists('t:git')
+  if !exists('t:agit_git')
     return
   endif
   if tabpagenr('$') == 1
@@ -153,12 +153,12 @@ function! agit#show_commit()
 endfunction
 
 function! agit#reload() abort
-  if !exists('t:git')
+  if !exists('t:agit_git')
     return
   endif
   try
     let w:agit_tracer = getpos('.')
-    call t:git.fire_init()
+    call t:agit_git.fire_init()
   finally
     for w in range(1, winnr('$'))
       let win = getwinvar(w, '')
@@ -175,15 +175,15 @@ endfunction
 
 function! agit#diff(args) abort
   try
-    if !exists('t:git')
+    if !exists('t:agit_git')
       return
     endif
     if &filetype ==# 'agit'
-      let filepath = t:git.relpath()
+      let filepath = t:agit_git.relpath()
     else
       let filepath = expand('<cfile>')
     endif
-    call agit#diff#sidebyside(t:git, filepath, a:args)
+    call agit#diff#sidebyside(t:agit_git, filepath, a:args)
   catch /Agit: /
     echohl ErrorMsg | echomsg v:exception | echohl None
   endtry
@@ -253,7 +253,7 @@ function! agit#agitgit(arg, confirm, bang)
   let arg = substitute(a:arg, '\c<hash>', agit#extract_hash(getline('.')), 'g')
   if match(arg, '\c<branch>') >= 0
     let cword = expand('<cword>')
-    silent let branch = agit#git#exec('rev-parse --symbolic ' . cword, t:git.git_root)
+    silent let branch = agit#git#exec('rev-parse --symbolic ' . cword, t:agit_git.git_root)
     let branch = substitute(branch, '\n\+$', '', '')
     if agit#git#get_last_status() != 0
       echomsg 'Not a branch name: ' . cword
@@ -274,7 +274,7 @@ function! agit#agitgit(arg, confirm, bang)
         return
       endif
     endif
-    echo agit#git#exec(arg, t:git.git_root, a:bang)
+    echo agit#git#exec(arg, t:agit_git.git_root, a:bang)
     call agit#reload()
   endif
 endfunction
@@ -291,7 +291,7 @@ function! agit#agit_git_compl(arglead, cmdline, cursorpos)
 endfunction
 
 function! agit#revision_list()
-  let revs = agit#git#exec('rev-parse --symbolic --branches --remotes --tags', t:git.git_root)
+  let revs = agit#git#exec('rev-parse --symbolic --branches --remotes --tags', t:agit_git.git_root)
   \ . join(['HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'FETCH_HEAD'], "\n")
   let hash = agit#extract_hash(getline('.'))
   if hash != ''
@@ -302,21 +302,21 @@ function! agit#revision_list()
 endfunction
 
 function! s:git_checkout(branch_name)
-  echo agit#git#exec('checkout ' . a:branch_name, t:git.git_root)
+  echo agit#git#exec('checkout ' . a:branch_name, t:agit_git.git_root)
   call agit#reload()
 endfunction
 
 function! s:git_checkout_b()
   let branch_name = input('git checkout -b ')
   echo ''
-  echo agit#git#exec('checkout -b ' . branch_name, t:git.git_root)
+  echo agit#git#exec('checkout -b ' . branch_name, t:agit_git.git_root)
   call agit#reload()
 endfunction
 
 function! s:git_branch_d(branch_name)
   echon "Are you sure you want to delete branch '" . a:branch_name . "' [y/N]"
   if nr2char(getchar()) ==# 'y'
-    echo agit#git#exec('branch -D ' . a:branch_name, t:git.git_root)
+    echo agit#git#exec('branch -D ' . a:branch_name, t:agit_git.git_root)
     call agit#reload()
   endif
 endfunction

--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -157,14 +157,14 @@ function! agit#reload() abort
     return
   endif
   try
-    let w:tracer = getpos('.')
+    let w:agit_tracer = getpos('.')
     call t:git.fire_init()
   finally
     for w in range(1, winnr('$'))
       let win = getwinvar(w, '')
-      if has_key(win, 'tracer')
-        let pos = win.tracer
-        unlet win.tracer
+      if has_key(win, 'agit_tracer')
+        let pos = win.agit_tracer
+        unlet win.agit_tracer
         execute 'noautocmd ' . w . 'wincmd w'
         call setpos('.', pos)
         break

--- a/autoload/agit.vim
+++ b/autoload/agit.vim
@@ -114,10 +114,10 @@ function! agit#print_commitmsg()
 endfunction
 
 function! agit#remote_scroll(win_type, direction)
-  if !exists('w:view')
+  if !exists('w:agit_view')
     return
   endif
-  let win_save = w:view.name
+  let win_save = w:agit_view.name
   if !agit#bufwin#move_to(a:win_type)
     return
   endif
@@ -147,8 +147,8 @@ function! agit#exit()
 endfunction
 
 function! agit#show_commit()
-  if has_key(w:, 'view') && has_key(w:view, 'emmit')
-    call w:view.emmit()
+  if has_key(w:, 'agit_view') && has_key(w:agit_view, 'emmit')
+    call w:agit_view.emmit()
   endif
 endfunction
 

--- a/autoload/agit/bufwin.vim
+++ b/autoload/agit/bufwin.vim
@@ -2,7 +2,7 @@ function! agit#bufwin#agit_tabnew(git)
   tabnew
   for v in a:git.views
     call s:run_layout(get(v, 'layout', ''))
-    let w:view = agit#view#{v.name}#new(a:git)
+    let w:agit_view = agit#view#{v.name}#new(a:git)
   endfor
   call a:git.fire_init()
 endfunction
@@ -10,7 +10,7 @@ endfunction
 function! agit#bufwin#move_to(name)
   for w in range(1, winnr('$'))
     let win = getwinvar(w, '')
-    if has_key(win, 'view') && has_key(win.view, 'name') && win.view.name ==# a:name
+    if has_key(win, 'agit_view') && has_key(win.agit_view, 'name') && win.agit_view.name ==# a:name
       execute w . 'wincmd w'
       return 1
     endif

--- a/autoload/agit/diff.vim
+++ b/autoload/agit/diff.vim
@@ -13,12 +13,12 @@ let s:revspec_pattern = '\v^(.{-})%((\.{2,3})(.*))?$'
 function! agit#diff#complete_revspec(arglead, ...)
   " return revision specification candidates (provide completion for AgitDiff)
   " revision specification patterns are 'R1', 'R1..R2', and 'R1...R2'
-  if !exists('t:git')
+  if !exists('t:agit_git')
     return []
   endif
   let matches = matchlist(a:arglead, s:revspec_pattern)
   let [rev1, dots, rev2] = matches[1:3]
-  let revs = agit#diff#revision_list(t:git)
+  let revs = agit#diff#revision_list(t:agit_git)
   if empty(dots)
     return filter(revs, 'stridx(v:val, rev1) == 0')
   else

--- a/autoload/agit/git.vim
+++ b/autoload/agit/git.vim
@@ -177,7 +177,7 @@ endfunction
 function! s:git.get_mergebase(rev1, rev2)
   let rev1 = a:rev1 =~# '^\(un\)\?staged$' ? 'HEAD' : a:rev1
   let rev2 = a:rev2 =~# '^\(un\)\?staged$' ? 'HEAD' : a:rev2
-  return s:String.chomp(agit#git#exec_or_die('merge-base "' . rev1 . '" "' . rev2 . '"', t:git.git_root))
+  return s:String.chomp(agit#git#exec_or_die('merge-base "' . rev1 . '" "' . rev2 . '"', t:agit_git.git_root))
 endfunction
 
 function! s:git.get_shorthash(revspec)
@@ -186,7 +186,7 @@ function! s:git.get_shorthash(revspec)
   elseif a:revspec =~# '^\x\{7,\}$'
     return a:revspec[:6]
   endif
-  return s:String.chomp(agit#git#exec_or_die('rev-parse --short "' . a:revspec . '"', t:git.git_root))
+  return s:String.chomp(agit#git#exec_or_die('rev-parse --short "' . a:revspec . '"', t:agit_git.git_root))
 endfunction
 
 let s:seq = ''

--- a/autoload/agit/view/log.vim
+++ b/autoload/agit/view/log.vim
@@ -98,10 +98,6 @@ function! s:log.setlocal()
     autocmd CursorHold <buffer> if g:agit_enable_auto_show_commit | call s:show_commit() | endif
     autocmd BufLeave <buffer> if g:agit_enable_auto_show_commit | call s:cleanup() | endif
 
-    if exists('##QuitPre')
-      autocmd QuitPre <buffer> call s:exit()
-    endif
-
     autocmd BufEnter <buffer> if g:agit_enable_auto_refresh | call agit#reload() | endif
 
     autocmd ShellCmdPost <buffer> call agit#reload()
@@ -124,13 +120,6 @@ function! s:log.setlocal()
 
   function! s:cleanup()
     let &updatetime = s:save_ut
-  endfunction
-
-  function! s:exit()
-    if !exists('t:agit_git')
-      return
-    endif
-    silent! only!
   endfunction
 
   function! s:skip_empty_line()

--- a/autoload/agit/view/log.vim
+++ b/autoload/agit/view/log.vim
@@ -154,7 +154,7 @@ function! s:log.setlocal()
 endfunction
 
 function! s:emmit(force)
-  call w:view.emmit(a:force)
+  call w:agit_view.emmit(a:force)
 endfunction
 
 function! s:log.emmit(...)

--- a/autoload/agit/view/log.vim
+++ b/autoload/agit/view/log.vim
@@ -127,7 +127,7 @@ function! s:log.setlocal()
   endfunction
 
   function! s:exit()
-    if !exists('t:git')
+    if !exists('t:agit_git')
       return
     endif
     silent! only!

--- a/test/agit.vim
+++ b/test/agit.vim
@@ -264,7 +264,7 @@ function! s:suite.__reload_test__()
     call Expect(getline(1)).not.to_match(g:agit#git#unstaged_message)
     call agit#bufwin#move_to('stat')
     call agit#reload()
-    call Expect(w:view.name).to_equal('stat')
+    call Expect(w:agit_view.name).to_equal('stat')
     call agit#bufwin#move_to('log')
     call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
   endfunction
@@ -273,7 +273,7 @@ function! s:suite.__reload_test__()
     call Expect(getline(1)).not.to_match(g:agit#git#unstaged_message)
     call agit#bufwin#move_to('diff')
     call agit#reload()
-    call Expect(w:view.name).to_equal('diff')
+    call Expect(w:agit_view.name).to_equal('diff')
     call agit#bufwin#move_to('log')
     call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
   endfunction
@@ -283,7 +283,7 @@ function! s:suite.__reload_test__()
     vnew
     call agit#reload()
     call agit#bufwin#move_to('log')
-    call Expect(w:view.name).to_equal('log')
+    call Expect(w:agit_view.name).to_equal('log')
     call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
   endfunction
 
@@ -293,7 +293,7 @@ function! s:suite.__reload_test__()
     call Expect(winnr('$')).to_equal(3)
     new
     wincmd p
-    call Expect(w:view.name).to_equal('log')
+    call Expect(w:agit_view.name).to_equal('log')
     call Expect(getline(1)).to_match(g:agit#git#unstaged_message)
     let g:agit_enable_auto_refresh = 0
   endfunction

--- a/test/agit.vim
+++ b/test/agit.vim
@@ -251,7 +251,7 @@ function! s:suite.__reload_test__()
 
   function! reload.after_each()
     call delete(s:repo_path . 'clean/x')
-    call agit#git#exec('reset', t:git.git_root)
+    call agit#git#exec('reset', t:agit_git.git_root)
   endfunction
 
   function! reload.on_log_window()


### PR DESCRIPTION
- Rename the variables that were too simply named.
  They were exposed having risks to conflict with other variables possibly defined outside agit.vim.

- Remove the autocmd on `QuitPre` to exit.
  That could disturb us closing extra windows on such cases as below:
  - `:tabonly` at another tab.
  - `:tabclose` at the agit tab.
  - `:only` to concentrate an agit buffer or another buffer which's been opened in the same tab.

By the way, what is the reason to copy `win` from `w:` before `has_key(win, foo)` (not just `has_key(w:, foo)`)?